### PR TITLE
Corrected county codes for UK holidays - Easter Monday and late Summe…

### DIFF
--- a/Src/Nager.Date/PublicHolidays/UnitedKingdomProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/UnitedKingdomProvider.cs
@@ -68,12 +68,12 @@ namespace Nager.Date.PublicHolidays
 
             items.Add(new PublicHoliday(year, 3, 17, "Saint Patrick's Day", "Saint Patrick's Day", countryCode, null, new string[] { "GB-NIR" }));
             items.Add(new PublicHoliday(easterSunday.AddDays(-2), "Good Friday", "Good Friday", countryCode));
-            items.Add(new PublicHoliday(easterSunday.AddDays(1), "Easter Monday", "Easter Monday", countryCode));
+            items.Add(new PublicHoliday(easterSunday.AddDays(1), "Easter Monday", "Easter Monday", countryCode, null, new string[] { "GB-ENG", "GB-WLS", "GB-NIR" }));
             items.Add(new PublicHoliday(lastMondayInMay, "Spring Bank Holiday", "Spring Bank Holiday", countryCode, 1971));
             items.Add(new PublicHoliday(year, 11, 30, "Saint Andrew's Day", "Saint Andrew's Day", countryCode, null, new string[] { "GB-SCT" }));
             items.Add(new PublicHoliday(year, 7, 12, "Battle of the Boyne", "Battle of the Boyne", countryCode, null, new string[] { "GB-NIR" }));
             items.Add(new PublicHoliday(firstMondayInAugust, "Summer Bank Holiday", "Summer Bank Holiday", countryCode, 1971, new string[] { "GB-SCT" }));
-            items.Add(new PublicHoliday(lastMondayInAugust, "Summer Bank Holiday", "Summer Bank Holiday", countryCode, 1971, new string[] { "GB-ENG", "GB-WLS" }));
+            items.Add(new PublicHoliday(lastMondayInAugust, "Summer Bank Holiday", "Summer Bank Holiday", countryCode, 1971, new string[] { "GB-ENG", "GB-WLS", "GB-NIR" }));
 
             #region Early May Bank Holiday
 


### PR DESCRIPTION
Corrected the county codes for 2 UK public bank holidays, can confirm using below sources

https://en.wikipedia.org/wiki/Public_holidays_in_the_United_Kingdom
https://www.independent.co.uk/life-style/uk-bank-holidays-2020-when-what-days-off-christmas-easter-dates-a9255231.html