### PR TITLE
Fixed Christmas Day and Boxing Day bank holidays

### DIFF
--- a/Src/Nager.Date.UnitTest/Country/UnitedKingdomTest.cs
+++ b/Src/Nager.Date.UnitTest/Country/UnitedKingdomTest.cs
@@ -64,7 +64,7 @@ namespace Nager.Date.UnitTest.Country
         [DataRow(2019, 12, 25, 26)]
         [DataRow(2020, 12, 25, 28)]
         [DataRow(2021, 12, 27, 28)]
-        public void CheckChristmasDay(int year, int month, int expectedChristmasDay, int expectedBoxingDay)
+        public void CheckChristmasDayAndBoxingDay(int year, int month, int expectedChristmasDay, int expectedBoxingDay)
         {
             Assert.IsTrue(DateSystem.IsPublicHoliday(new DateTime(year, month, expectedChristmasDay), CountryCode.GB));
             Assert.IsTrue(DateSystem.IsPublicHoliday(new DateTime(year, month, expectedBoxingDay), CountryCode.GB));

--- a/Src/Nager.Date.UnitTest/Country/UnitedKingdomTest.cs
+++ b/Src/Nager.Date.UnitTest/Country/UnitedKingdomTest.cs
@@ -55,5 +55,19 @@ namespace Nager.Date.UnitTest.Country
 
             Assert.AreEqual(expected, result);
         }
+        
+        [TestMethod]
+        [DataRow(2015, 12, 25, 28)]
+        [DataRow(2016, 12, 27, 26)]
+        [DataRow(2017, 12, 25, 26)]
+        [DataRow(2018, 12, 25, 26)]
+        [DataRow(2019, 12, 25, 26)]
+        [DataRow(2020, 12, 25, 28)]
+        [DataRow(2021, 12, 27, 28)]
+        public void CheckChristmasDay(int year, int month, int expectedChristmasDay, int expectedBoxingDay)
+        {
+            Assert.IsTrue(DateSystem.IsPublicHoliday(new DateTime(year, month, expectedChristmasDay), CountryCode.GB));
+            Assert.IsTrue(DateSystem.IsPublicHoliday(new DateTime(year, month, expectedBoxingDay), CountryCode.GB));
+        }
     }
 }

--- a/Src/Nager.Date/PublicHolidays/UnitedKingdomProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/UnitedKingdomProvider.cs
@@ -92,14 +92,14 @@ namespace Nager.Date.PublicHolidays
 
             #region Christmas Day with fallback
 
-            var christmasDay = new DateTime(year, 12, 25).Shift(saturday => saturday.AddDays(3), sunday => sunday.AddDays(2));
+            var christmasDay = new DateTime(year, 12, 25).Shift(saturday => saturday.AddDays(2), sunday => sunday.AddDays(2));
             items.Add(new PublicHoliday(christmasDay, "Christmas Day", "Christmas Day", countryCode));
 
             #endregion
 
             #region St. Stephen's Day with fallback
 
-            var sanktStehpenDay = new DateTime(year, 12, 26).Shift(saturday => saturday.AddDays(2), sunday => sunday.AddDays(1));
+            var sanktStehpenDay = new DateTime(year, 12, 26).Shift(saturday => saturday.AddDays(2), sunday => sunday.AddDays(2));
             items.Add(new PublicHoliday(sanktStehpenDay, "Boxing Day", "St. Stephen's Day", countryCode));
 
             #endregion


### PR DESCRIPTION
* Fixed Christmas Day and Boxing Day date handling for scenarios where Christmas Day is a Sunday, or Boxing Day is a Saturday.

Substitute days should now be as below:

Scenario 1: Christmas Day on Saturday and Boxing Day on Sunday (see 2021)
    - Christmas Day has a substitute day of the following Monday.
    - Boxing Day has a substitute day of the following Tuesday.
Scenario 2: Christmas Day on Sunday, Boxing Day on Monday (see 2016)
    - Christmas Day has a substitute day of the following Tuesday.
    - Boxing Day remains unchanged.
Scenario 3: Christmas Day on Friday, Boxing Day on Saturday (see 2020)
    - Christmas day remains unchanged.
    - Boxing Day has a substitute day of the following Monday.

Reference for the three scenarios: https://web.archive.org/web/20200624132154/https://www.gov.uk/bank-holidays