### PR TITLE
Croatia 2020 Remembrance Day addition and Independece Day exclusion

### DIFF
--- a/Src/Nager.Date/PublicHolidays/CroatiaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/CroatiaProvider.cs
@@ -41,28 +41,56 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(year, 6, 22, "Dan antifašističke borbe", "Anti-Fascist Struggle Day", countryCode));
             items.Add(new PublicHoliday(year, 8, 5, "Dan pobjede i domovinske zahvalnosti i Dan hrvatskih branitelja", "Victory and Homeland Thanksgiving Day and the Day of Croatian defenders", countryCode));
             items.Add(new PublicHoliday(year, 8, 15, "Velika Gospa", "Assumption Day", countryCode));
-            items.Add(new PublicHoliday(year, 10, 8, "Dan neovisnosti", "Independence Day", countryCode));
             items.Add(new PublicHoliday(year, 11, 1, "Dan svih svetih", "All Saints' Day", countryCode));
-            items.Add(new PublicHoliday(year, 11, 18, "Dan sjećanja na žrtve Domovinskog rata", "Remembrance Day for Homeland War Victims", countryCode, 2020));
             items.Add(new PublicHoliday(year, 12, 25, "Božić", "Christmas Day", countryCode));
             items.Add(new PublicHoliday(year, 12, 26, "Prvi dan po Božiću, Sveti Stjepan, Štefanje, Stipanje", "St.Stephen's Day", countryCode));
 
+            items.Add(this.GetIndependenceDay(year, countryCode));
+            items.Add(this.GetRemembranceDay(year, countryCode));
             items.Add(this.GetStatehoodDay(year, countryCode));
+            items.Add(this.GetNationalDay(year, countryCode));
 
             return items.OrderBy(o => o.Date);
         }
 
-        private PublicHoliday GetStatehoodDay(int year, CountryCode countryCode)
+        private PublicHoliday GetIndependenceDay(int year, CountryCode countryCode)
         {
-            var localName = "Dan državnosti";
-            var englishName = "Statehood Day";
-
             if (year < 2020)
             {
-                return new PublicHoliday(year, 6, 25, localName, englishName, countryCode);
+                return new PublicHoliday(year, 10, 8, "Dan neovisnosti", "Independence Day", countryCode);
             }
 
-            return new PublicHoliday(year, 5, 30, localName, englishName, countryCode);
+            return null;
+        }
+
+        private PublicHoliday GetRemembranceDay(int year, CountryCode countryCode)
+        {
+            if (year > 2020)
+            {
+                return new PublicHoliday(year, 11, 18, "Dan sjećanja na žrtve Domovinskog rata", "Remembrance Day", countryCode);
+            }
+
+            return null;
+        }
+
+        private PublicHoliday GetStatehoodDay(int year, CountryCode countryCode)
+        {
+            if (year < 2020)
+            {
+                return new PublicHoliday(year, 6, 25, "Dan državnosti", "Statehood Day", countryCode);
+            }
+
+            return null;
+        }
+
+        private PublicHoliday GetNationalDay(int year, CountryCode countryCode)
+        {
+            if (year > 2020)
+            {
+                return new PublicHoliday(year, 5, 30, "Dan državnosti", "National Day", countryCode);
+            }
+
+            return null;
         }
 
         /// <summary>


### PR DESCRIPTION
In 2020 there was a change in holidays: June 25 (Statehood Day) and October 8 (Independence Day) were demoted from public holidays to memorial days, and May 30 (National Day) and November 18 (Remembrance Day) were promoted from memorial days to public holidays.