### PR TITLE
Added logic for when Sweden switched National Day to be a public holiday

### DIFF
--- a/Src/Nager.Date.UnitTest/Country/SwedenTest.cs
+++ b/Src/Nager.Date.UnitTest/Country/SwedenTest.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Nager.Date.Extensions;
+using System;
+
+namespace Nager.Date.UnitTest.Country
+{
+    [TestClass]
+    public class SwedenTest
+    {
+        [TestMethod]
+        [DataRow(2000, false)]
+        [DataRow(2004, false)]
+        [DataRow(2005, true)]
+        [DataRow(2020, true)]
+        public void CheckThatNationalDayIsAddedAsPublicHolidayYear2005AndOnwards(int year, bool expected)
+        {
+            // Arrange
+            var date = new DateTime(year, 6, 6);
+
+            // Act
+            var result = DateSystem.IsPublicHoliday(date, CountryCode.SE);
+
+            // Assert
+            Assert.AreEqual(expected, result, date.ToString());
+        }
+
+        [TestMethod]
+        [DataRow(2000, 6, 12, true)]
+        [DataRow(2004, 5, 31, true)]
+        [DataRow(2005, 5, 16, false)]
+        [DataRow(2020, 6, 01, false)]
+        public void CheckThatPentecostMondayIsRemovedAsPublicHolidayAfterYear2004(int year, int month, int day, bool expected)
+        {
+            // Arrange
+            var date = new DateTime(year, month, day);
+
+            // Act
+            var result = DateSystem.IsPublicHoliday(date, CountryCode.SE);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+    }
+}

--- a/Src/Nager.Date/PublicHolidays/SwedenProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/SwedenProvider.cs
@@ -43,8 +43,15 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(easterSunday.AddDays(1), "Annandag påsk", "Easter Monday", countryCode));
             items.Add(new PublicHoliday(year, 5, 1, "Första maj", "International Workers' Day", countryCode));
             items.Add(new PublicHoliday(easterSunday.AddDays(39), "Kristi himmelsfärds dag", "Ascension Day", countryCode));
-            items.Add(new PublicHoliday(year, 6, 6, "Sveriges nationaldag", "National Day of Sweden", countryCode));
+            if (year >= 2005)
+            {
+                items.Add(new PublicHoliday(year, 6, 6, "Sveriges nationaldag", "National Day of Sweden", countryCode));
+            }
             items.Add(new PublicHoliday(easterSunday.AddDays(49), "Pingstdagen", "Pentecost Sunday", countryCode));
+            if (year < 2005)
+            {
+                items.Add(new PublicHoliday(easterSunday.AddDays(50), "Annandag Pingst", "Pentecost Monday", countryCode));
+            }
             items.Add(new PublicHoliday(midsummerDay.AddDays(-1), "Midsommarafton", "Midsummer Eve", countryCode));
             items.Add(new PublicHoliday(midsummerDay, "Midsommar", "Midsummer Day", countryCode));
             items.Add(new PublicHoliday(allSaintsDay, "Alla helgons dag", "All Saints' Day", countryCode));


### PR DESCRIPTION
This fix is not a big thing since the current logic works fine for the last 15 years, today and in the foreseeable future. But this fix corrects a historical incorrectness.

Sweden haven't had the National Day as a public holiday forever. Historically, Pentecost Monday (not sure this is what it is called in English, in Swedish it is "Annandag Pingst") used to be a public holiday instead but those two were exchanged starting by the year 2005 to follow the current logic.

I didn't find this information on the English Wikipedia page (yeah, oddly enough they don't keep track of all the tiny Swedish calendar details...) but it can be verified by google translate the Swedish Wikipedia page: https://sv.wikipedia.org/wiki/Sveriges_nationaldag.