### PR TITLE
Removed get age

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,6 @@ if (DateSystem.IsWeekend(date, CountryCode.DE))
 }
 ```
 
-### Calculate age
-```cs
-var date = new DateTime(1900, 1, 1);
-var age = DateSystem.GetAge(date);
-```
-
 ## Country Support
 
 The list of supported countries can be found on the [wiki](https://github.com/nager/Nager.Date/wiki/Supported-Countries).

--- a/Src/Nager.Date/DateSystem.cs
+++ b/Src/Nager.Date/DateSystem.cs
@@ -635,24 +635,6 @@ namespace Nager.Date
 
         #endregion
 
-        #region Birthday
-
-        /// <summary>
-        /// Get the age of a person from a given date
-        /// </summary>
-        /// <param name="birthdate">The birthdate</param>
-        /// <returns></returns>
-        public static int GetAge(DateTime birthdate)
-        {
-            var today = DateTime.UtcNow;
-            var age = today.Year - birthdate.Year;
-            if (birthdate > today.AddYears(-age)) age--;
-
-            return age;
-        }
-
-        #endregion
-
         #region Long Weekends
 
         /// <summary>

--- a/Src/Nager.Date/Nager.Date.csproj
+++ b/Src/Nager.Date/Nager.Date.csproj
@@ -8,7 +8,18 @@
     <Authors>Tino Hager</Authors>
     <PackageReleaseNotes>
   - Removed `DateSystem.GetDate` method, because this method does not fit thematically anymore.
-  - Revised internal management of holiday providers so that they are loaded only as needed.
+  - Converted NoHolidaysProvider to singleton
+    NoHolidaysProvider converted to a singleton to minimize the number of object references held.
+  - Refactored DateSystem.GetWeekendProvider
+    To use the return value of .TryGetValue instead of an additional null check
+  - Converted _publicHolidaysProviders to Lazy Values
+    This ensures that all content is available. However, only instantiated by the initial call, so that only the providers that are needed are loaded.
+  - Fixed UnitTest based on latest changes on NoHolidayProvider
+  - Use Keys collection instead of iterating the KeyValuePairs.
+  - Simplified usage of FindDay
+    Instead of splitting the date components to use them.
+  - Instantiates only once per WeekendProvider instead of on every call.
+  - Creates the respective IWeekendProviders only as needed.
     </PackageReleaseNotes>
     <PackageTags>Public-Holiday PublicHoliday Bank-Holiday BankHoliday FederalHoliday NationalHoliday Åland Andorra Argentina Austria Australia Bahamas Barbados Belarus Belgium Belize Benin Bolivia Botswana Brazil Bulgaria Canada Chile China Colombia CostaRica Croatia Cuba Cyprus CzechRepublic Denmark DominicanRepublic Ecuador Egypt ElSalvador Estonia FaroeIslands Finland France Gabon Gambia Germany Greece Grenada Guatemala Guyana Haiti Honduras Hungary Iceland Indonesia Ireland IsleOfMan Italy Jamaica Jersey Latvia Lesotho Liechtenstein Lithuania Luxembourg Macedonia Madagascar Malta Mexico Moldova Monaco Mongolia Morocco Mozambique Namibia Netherlands Nicaragua Niger Norway NewZealand Panana Paraguay Peru Poland Portugal PuertoRico Romania Russia SanMarino Serbia SvalbardAndJanMayen Slovakia Slovenia SouthAfrica Spain Surianme Sweden Switzerland Tunisia Venezuela Ukraine UnitedKingdom UnitedStates Uruguay VaticanCity Vietnam</PackageTags>
     <PackageProjectUrl>https://date.nager.at</PackageProjectUrl>

--- a/Src/Nager.Date/Nager.Date.csproj
+++ b/Src/Nager.Date/Nager.Date.csproj
@@ -4,9 +4,12 @@
     <TargetFrameworks>net45;net461;netstandard2.0</TargetFrameworks>
     <Description>Calculate Public Holidays / Federal Holidays for a given year, translation native and english. Country and County support. Supports more than 100 countries</Description>
     <Company>nager.at</Company>
-    <Version>1.26.7</Version>
+    <Version>1.27.0</Version>
     <Authors>Tino Hager</Authors>
-    <PackageReleaseNotes>Spain - Fix boe.es</PackageReleaseNotes>
+    <PackageReleaseNotes>
+  - Removed `DateSystem.GetDate` method, because this method does not fit thematically anymore.
+  - Revised internal management of holiday providers so that they are loaded only as needed.
+    </PackageReleaseNotes>
     <PackageTags>Public-Holiday PublicHoliday Bank-Holiday BankHoliday FederalHoliday NationalHoliday Åland Andorra Argentina Austria Australia Bahamas Barbados Belarus Belgium Belize Benin Bolivia Botswana Brazil Bulgaria Canada Chile China Colombia CostaRica Croatia Cuba Cyprus CzechRepublic Denmark DominicanRepublic Ecuador Egypt ElSalvador Estonia FaroeIslands Finland France Gabon Gambia Germany Greece Grenada Guatemala Guyana Haiti Honduras Hungary Iceland Indonesia Ireland IsleOfMan Italy Jamaica Jersey Latvia Lesotho Liechtenstein Lithuania Luxembourg Macedonia Madagascar Malta Mexico Moldova Monaco Mongolia Morocco Mozambique Namibia Netherlands Nicaragua Niger Norway NewZealand Panana Paraguay Peru Poland Portugal PuertoRico Romania Russia SanMarino Serbia SvalbardAndJanMayen Slovakia Slovenia SouthAfrica Spain Surianme Sweden Switzerland Tunisia Venezuela Ukraine UnitedKingdom UnitedStates Uruguay VaticanCity Vietnam</PackageTags>
     <PackageProjectUrl>https://date.nager.at</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
As previously discussed, here is the remove of the `DateSystem.GetAge` method as well as the Version Bump with Release Notes.