### PR TITLE
Feature/cleanup shift shiftweekdays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 ### Changed
 - Straighten method names GetPublicHoliday to GetPublicHolidays
+- Simplified Shift and ShiftWeekdays
 ### Deprecated
 ### Removed
 ### Fixed

--- a/Src/Nager.Date/DateSystem.cs
+++ b/Src/Nager.Date/DateSystem.cs
@@ -13,7 +13,6 @@ namespace Nager.Date
     /// </summary>
     public static class DateSystem
     {
-        private const bool IsObsolete2022 = false;
 
         private static readonly ICatholicProvider _catholicProvider = new CatholicProvider();
         private static readonly IOrthodoxProvider _orthodoxProvider = new OrthodoxProvider();
@@ -236,7 +235,7 @@ namespace Nager.Date
         /// <param name="year">The year</param>
         /// <param name="countryCode">Country Code (ISO 3166-1 ALPHA-2)</param>
         /// <returns></returns>
-        [Obsolete("Use GetPublicHolidays instead", IsObsolete2022)]
+        [Obsolete("Use GetPublicHolidays instead", Flags.IsObsolete2022)]
         public static IEnumerable<PublicHoliday> GetPublicHoliday(int year, string countryCode)
         {
             return GetPublicHolidays(year, countryCode);
@@ -277,7 +276,7 @@ namespace Nager.Date
         /// <param name="year">The year</param>
         /// <param name="countryCode">Country Code (ISO 3166-1 ALPHA-2)</param>
         /// <returns></returns>
-        [Obsolete("Use GetPublicHolidays instead", IsObsolete2022)]
+        [Obsolete("Use GetPublicHolidays instead", Flags.IsObsolete2022)]
         public static IEnumerable<PublicHoliday> GetPublicHoliday(int year, CountryCode countryCode)
         {
             return GetPublicHolidays(year, countryCode);
@@ -324,7 +323,7 @@ namespace Nager.Date
         /// <param name="endDate">The end date</param>
         /// <param name="countryCode">Country Code (ISO 3166-1 ALPHA-2)</param>
         /// <returns></returns>
-        [Obsolete("Use GetPublicHolidays instead", IsObsolete2022)]
+        [Obsolete("Use GetPublicHolidays instead", Flags.IsObsolete2022)]
         public static IEnumerable<PublicHoliday> GetPublicHoliday(DateTime startDate, DateTime endDate, string countryCode)
         {
             return GetPublicHolidays(startDate, endDate, countryCode);
@@ -386,7 +385,7 @@ namespace Nager.Date
         /// <param name="endDate">The end date</param>
         /// <param name="countryCode">Country Code (ISO 3166-1 ALPHA-2)</param>
         /// <returns></returns>
-        [Obsolete("Use GetPublicHolidays instead", IsObsolete2022)]
+        [Obsolete("Use GetPublicHolidays instead", Flags.IsObsolete2022)]
         public static IEnumerable<PublicHoliday> GetPublicHoliday(DateTime startDate, DateTime endDate, CountryCode countryCode)
         {
             return GetPublicHolidays(startDate, endDate, countryCode);

--- a/Src/Nager.Date/Extensions/DateTimeExtension.cs
+++ b/Src/Nager.Date/Extensions/DateTimeExtension.cs
@@ -1,7 +1,9 @@
-﻿using System;
+using System;
 
 namespace Nager.Date.Extensions
 {
+    using System.Runtime.CompilerServices;
+
     /// <summary>
     /// DateTimeExtension
     /// </summary>
@@ -27,6 +29,7 @@ namespace Nager.Date.Extensions
         /// <param name="sunday">shift for Sunday</param>
         /// <param name="monday">shift for Monday</param>
         /// <returns></returns>
+        [Obsolete("Please use .Shift(DateTime, int, int, int = default) instead", Flags.IsObsolete2022)]
         public static DateTime Shift(this DateTime value, Func<DateTime, DateTime> saturday, Func<DateTime, DateTime> sunday, Func<DateTime, DateTime> monday = null)
         {
             switch (value.DayOfWeek)
@@ -49,6 +52,28 @@ namespace Nager.Date.Extensions
             }
 
             return value;
+        }
+
+        /// <summary>
+        /// If the given date on this Weekday it can be shifted
+        /// </summary>
+        /// <param name="value">The date to evaluate</param>
+        /// <param name="saturday">Shift Saturdays by x days, 0 disables shifting.</param>
+        /// <param name="sunday">Shift Sundays by x days, 0 disables shifting.</param>
+        /// <param name="monday">Shift Mondays by x days, 0 disables shifting.</param>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static DateTime Shift(this DateTime value, int saturday, int sunday, int monday = default)
+        {
+            var shiftBy = value.DayOfWeek switch
+            {
+                DayOfWeek.Saturday => saturday,
+                DayOfWeek.Sunday => sunday,
+                DayOfWeek.Monday => monday,
+                _ => default
+            };
+
+            return shiftBy == default ? value : value.AddDays(shiftBy);
         }
 
         /// <summary>
@@ -78,6 +103,7 @@ namespace Nager.Date.Extensions
         /// <param name="thursday"></param>
         /// <param name="friday"></param>
         /// <returns></returns>
+        [Obsolete("Please use .ShiftWeekdays(DateTime, int = default, int = default, int = default, int = default, int = default) instead", Flags.IsObsolete2022)]
         public static DateTime ShiftWeekdays(this DateTime value, Func<DateTime, DateTime> monday = null, Func<DateTime, DateTime> tuesday = null, Func<DateTime, DateTime> wednesday = null, Func<DateTime, DateTime> thursday = null, Func<DateTime, DateTime> friday = null)
         {
             switch (value.DayOfWeek)
@@ -122,6 +148,33 @@ namespace Nager.Date.Extensions
             }
 
             return value;
+        }
+
+        /// <summary>
+        /// If the given date on this Weekday it can be shifted
+        /// </summary>
+        /// <param name="value">The date to evaluate</param>
+        /// <param name="monday">Shift Mondays by x days, 0 disables shifting.</param>
+        /// <param name="tuesday">Shift Tuesdays by x days, 0 disables shifting.</param>
+        /// <param name="wednesday">Shift Wednesdays by x days, 0 disables shifting.</param>
+        /// <param name="thursday">Shift Thursdays by x days, 0 disables shifting.</param>
+        /// <param name="friday">Shift Fridays by x days, 0 disables shifting.</param>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static DateTime ShiftWeekdays(this DateTime value, int monday = default, int tuesday = default, int wednesday = default, int thursday = default, int friday = default)
+        {
+
+            var shiftBy = value.DayOfWeek switch
+            {
+                DayOfWeek.Monday => monday,
+                DayOfWeek.Tuesday => tuesday,
+                DayOfWeek.Wednesday => wednesday,
+                DayOfWeek.Thursday => thursday,
+                DayOfWeek.Friday => friday,
+                _ => default
+            };
+
+            return shiftBy == default ? value : value.AddDays(shiftBy);
         }
     }
 }

--- a/Src/Nager.Date/Flags.cs
+++ b/Src/Nager.Date/Flags.cs
@@ -1,0 +1,13 @@
+namespace Nager.Date
+{
+    /// <summary>
+    /// Internal flags to manage and control features and functions.
+    /// </summary>
+    internal static class Flags
+    {
+        /// <summary>
+        /// Marks obsolete functions for deletion, beginning 2022.
+        /// </summary>
+        public const bool IsObsolete2022 = false;
+    }
+}

--- a/Src/Nager.Date/Nager.Date.csproj
+++ b/Src/Nager.Date/Nager.Date.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0;net5.0</TargetFrameworks>
@@ -16,6 +16,9 @@
     <RepositoryUrl>https://github.com/nager/Nager.Date</RepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+
+    <!-- Use latest c# LangVersion to support new language features -->
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,12 +30,12 @@
       <Pack>true</Pack>
       <PackagePath>\</PackagePath>
     </Content>
-  
+
     <None Include="..\..\Doc\Icons\calendar.png">
       <Pack>true</Pack>
       <Visible>false</Visible>
       <PackagePath></PackagePath>
     </None>
   </ItemGroup>
-  
+
 </Project>

--- a/Src/Nager.Date/PublicHolidays/AustraliaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/AustraliaProvider.cs
@@ -54,8 +54,8 @@ namespace Nager.Date.PublicHolidays
             var firstMondayInAugust = DateSystem.FindDay(year, Month.August, DayOfWeek.Monday, Occurrence.First);
             var firstMondayInOctober = DateSystem.FindDay(year, Month.October, DayOfWeek.Monday, Occurrence.First);
 
-            var boxingDay = new DateTime(year, 12, 26).Shift(saturday => saturday.AddDays(2), sunday => sunday.AddDays(1));
-            var australiaDay = new DateTime(year, 1, 26).Shift(saturday => saturday.AddDays(2), sunday => sunday.AddDays(1));
+            var boxingDay = new DateTime(year, 12, 26).Shift(2, 1);
+            var australiaDay = new DateTime(year, 1, 26).Shift(2, 1);
 
             var easterSunday1 = this._catholicProvider.EasterSunday("Easter Sunday", year, countryCode);
             easterSunday1.SetCounties("AUS-ACT", "AUS-NSW", "AUS-VIC");

--- a/Src/Nager.Date/PublicHolidays/BelizeProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/BelizeProvider.cs
@@ -33,18 +33,14 @@ namespace Nager.Date.PublicHolidays
 
             #region New Year's Day
 
-            var newYearsDay = new DateTime(year, 1, 1).Shift(saturday => saturday.AddDays(2), sunday => sunday);
+            var newYearsDay = new DateTime(year, 1, 1).Shift(2, 0);
             items.Add(new PublicHoliday(newYearsDay, "New Year's Day", "New Year's Day", countryCode));
 
             #endregion
 
             #region Baron Bliss Day
 
-            var baronBlissDay = new DateTime(year, 3, 9).ShiftWeekdays(
-                tuesday: tuesday => tuesday.AddDays(-1),
-                wednesday: wednesday => wednesday.AddDays(-2),
-                thursday: thursday => thursday.AddDays(-3)
-                );
+            var baronBlissDay = new DateTime(year, 3, 9).ShiftWeekdays(-1, -2, -3);
             items.Add(new PublicHoliday(baronBlissDay, "Baron Bliss Day", "Baron Bliss Day", countryCode));
 
             #endregion
@@ -56,64 +52,56 @@ namespace Nager.Date.PublicHolidays
 
             #region Labour Day
 
-            var labourDay = new DateTime(year, 5, 1).Shift(saturday => saturday.AddDays(2), sunday => sunday);
+            var labourDay = new DateTime(year, 5, 1).Shift(2, 0);
             items.Add(new PublicHoliday(labourDay, "Labour Day", "Labour Day", countryCode));
 
             #endregion
 
             #region Commonwealth Day
 
-            var commonwealthDay = new DateTime(year, 5, 24).ShiftWeekdays(
-                tuesday: tuesday => tuesday.AddDays(-1),
-                wednesday: wednesday => wednesday.AddDays(-2),
-                thursday: thursday => thursday.AddDays(-3)
-                );
+            var commonwealthDay = new DateTime(year, 5, 24).ShiftWeekdays(-1, -2, -3);
             items.Add(new PublicHoliday(commonwealthDay, "Commonwealth Day", "Commonwealth Day", countryCode));
 
             #endregion
 
             #region Saint George's Caye Day
 
-            var saintGeorgesCayeDay = new DateTime(year, 9, 10).Shift(saturday => saturday.AddDays(2), sunday => sunday);
+            var saintGeorgesCayeDay = new DateTime(year, 9, 10).Shift(2, 0);
             items.Add(new PublicHoliday(saintGeorgesCayeDay, "Saint George's Caye Day", "Saint George's Caye Day", countryCode));
 
             #endregion
 
             #region Independence Day
 
-            var independenceDay = new DateTime(year, 9, 21).Shift(saturday => saturday.AddDays(2), sunday => sunday);
+            var independenceDay = new DateTime(year, 9, 21).Shift(2, 0);
             items.Add(new PublicHoliday(independenceDay, "Independence Day", "Independence Day", countryCode));
 
             #endregion
 
             #region Day of the Americas
 
-            var dayOfTheAmericas = new DateTime(year, 10, 12).ShiftWeekdays(
-                tuesday: tuesday => tuesday.AddDays(-1),
-                wednesday: wednesday => wednesday.AddDays(-2),
-                thursday: thursday => thursday.AddDays(-3)
-                );
+            var dayOfTheAmericas = new DateTime(year, 10, 12).ShiftWeekdays(-1, -2, -3);
             items.Add(new PublicHoliday(dayOfTheAmericas, "Day of the Americas", "Day of the Americas", countryCode));
 
             #endregion
 
             #region Garifuna Settlement Day
 
-            var garifunaSettlementDay = new DateTime(year, 11, 19).Shift(saturday => saturday.AddDays(2), sunday => sunday);
+            var garifunaSettlementDay = new DateTime(year, 11, 19).Shift(2, 0);
             items.Add(new PublicHoliday(garifunaSettlementDay, "Garifuna Settlement Day", "Garifuna Settlement Day", countryCode));
 
             #endregion
 
             #region Christmas Day
 
-            var christmasDay = new DateTime(year, 12, 25).Shift(saturday => saturday.AddDays(2), sunday => sunday);
+            var christmasDay = new DateTime(year, 12, 25).Shift(2, 0);
             items.Add(new PublicHoliday(christmasDay, "Christmas Day", "Christmas Day", countryCode));
 
             #endregion
 
             #region Boxing Day
 
-            var boxingDay = new DateTime(year, 12, 26).Shift(saturday => saturday.AddDays(2), sunday => sunday);
+            var boxingDay = new DateTime(year, 12, 26).Shift(2, 0);
             items.Add(new PublicHoliday(boxingDay, "Boxing Day", "Boxing Day", countryCode));
 
             #endregion

--- a/Src/Nager.Date/PublicHolidays/ChileProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/ChileProvider.cs
@@ -54,7 +54,7 @@ namespace Nager.Date.PublicHolidays
 
             var items = new List<PublicHoliday>();
 
-            var newYearDay = new DateTime(year, 1, 1).Shift(saturday => saturday, sunday => sunday.AddDays(1));
+            var newYearDay = new DateTime(year, 1, 1).Shift(0, 1);
             items.Add(new PublicHoliday(newYearDay, "Año Nuevo", "New Year's Day", countryCode));
             items.Add(this._catholicProvider.GoodFriday("Viernes Santo", year, countryCode));
             items.Add(new PublicHoliday(easterSunday.AddDays(-1), "Sábado Santo", "Holy Saturday", countryCode));

--- a/Src/Nager.Date/PublicHolidays/JamaicaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/JamaicaProvider.cs
@@ -39,14 +39,14 @@ namespace Nager.Date.PublicHolidays
 
             #region Independence Day
 
-            var independenceDay = new DateTime(year, 8, 6).Shift(saturday => saturday, sunday => sunday.AddDays(1));
+            var independenceDay = new DateTime(year, 8, 6).Shift(0, 1);
             items.Add(new PublicHoliday(independenceDay, "Independence Day", "Independence Day", countryCode));
 
             #endregion
 
             items.Add(new PublicHoliday(year, 10, 16, "National Heroes Day", "National Heroes Day", countryCode));
             items.Add(new PublicHoliday(year, 12, 25, "Christmas Day", "Christmas Day", countryCode));
-            items.Add(new PublicHoliday(year, 12, 26, "Boxing Day", "St. Stephen's Day", countryCode));            
+            items.Add(new PublicHoliday(year, 12, 26, "Boxing Day", "St. Stephen's Day", countryCode));
 
             return items.OrderBy(o => o.Date);
         }

--- a/Src/Nager.Date/PublicHolidays/JapanProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/JapanProvider.cs
@@ -35,16 +35,16 @@ namespace Nager.Date.PublicHolidays
             var thirdMondayInSeptember = DateSystem.FindDay(year, Month.September, DayOfWeek.Monday, Occurrence.Third);
             var secondMondayInOctober = DateSystem.FindDay(year, Month.October, DayOfWeek.Monday, Occurrence.Second);
 
-            var newYearsDay = new DateTime(year, 1, 1).Shift(saturday => saturday, sunday => sunday.AddDays(1));
-            var foundationDay = new DateTime(year, 2, 11).Shift(saturday => saturday, sunday => sunday.AddDays(1));
-            var showaDay = new DateTime(year, 4, 29).Shift(saturday => saturday, sunday => sunday.AddDays(1));
-            var memorialDay = new DateTime(year, 5, 3).Shift(saturday => saturday, sunday => sunday.AddDays(1));
-            var greeneryDay = new DateTime(year, 5, 4).Shift(saturday => saturday, sunday => sunday.AddDays(1));
-            var childrensDay = new DateTime(year, 5, 5).Shift(saturday => saturday, sunday => sunday.AddDays(1));
-            var mountainDay = new DateTime(year, 8, 11).Shift(saturday => saturday, sunday => sunday.AddDays(1));
-            var cultureDay = new DateTime(year, 11, 3).Shift(saturday => saturday, sunday => sunday.AddDays(1));
-            var thanksgivingDay = new DateTime(year, 11, 23).Shift(saturday => saturday, sunday => sunday.AddDays(1));
-            var emperorsBirthday = new DateTime(year, 12, 23).Shift(saturday => saturday, sunday => sunday.AddDays(1));
+            var newYearsDay = new DateTime(year, 1, 1).Shift(0, 1);
+            var foundationDay = new DateTime(year, 2, 11).Shift(0, 1);
+            var showaDay = new DateTime(year, 4, 29).Shift(0, 1);
+            var memorialDay = new DateTime(year, 5, 3).Shift(0, 1);
+            var greeneryDay = new DateTime(year, 5, 4).Shift(0, 1);
+            var childrensDay = new DateTime(year, 5, 5).Shift(0, 1);
+            var mountainDay = new DateTime(year, 8, 11).Shift(0, 1);
+            var cultureDay = new DateTime(year, 11, 3).Shift(0, 1);
+            var thanksgivingDay = new DateTime(year, 11, 23).Shift(0, 1);
+            var emperorsBirthday = new DateTime(year, 12, 23).Shift(0, 1);
 
             var items = new List<PublicHoliday>();
             items.Add(new PublicHoliday(newYearsDay, "元日", "New Year's Day", countryCode));
@@ -75,7 +75,7 @@ namespace Nager.Date.PublicHolidays
         /// <param name="year"></param>
         public DateTime GetGoldenWeekStartDate(int year)
         {
-            var showaDay = new DateTime(year, 4, 29).Shift(saturday => saturday, sunday => sunday.AddDays(1));
+            var showaDay = new DateTime(year, 4, 29).Shift(0, 1);
 
             return showaDay;
         }

--- a/Src/Nager.Date/PublicHolidays/MexicoProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/MexicoProvider.cs
@@ -29,10 +29,10 @@ namespace Nager.Date.PublicHolidays
             var thirdMondayOfMarch = DateSystem.FindDay(year, Month.March, DayOfWeek.Monday, Occurrence.Third);
             var thirdMondayOfNovember = DateSystem.FindDay(year, Month.November, DayOfWeek.Monday, Occurrence.Third);
 
-            var newYearDay = new DateTime(year, 1, 1).Shift(saturday => saturday.AddDays(-1), sunday => sunday.AddDays(1));
-            var laborDay = new DateTime(year, 5, 1).Shift(saturday => saturday.AddDays(-1), sunday => sunday.AddDays(1));
-            var independenceDay = new DateTime(year, 9, 16).Shift(saturday => saturday.AddDays(-1), sunday => sunday.AddDays(1));
-            var inaugurationDay = new DateTime(year, 12, 1).Shift(saturday => saturday.AddDays(-1), sunday => sunday.AddDays(1));
+            var newYearDay = new DateTime(year, 1, 1).Shift(-1, 1);
+            var laborDay = new DateTime(year, 5, 1).Shift(-1, 1);
+            var independenceDay = new DateTime(year, 9, 16).Shift(-1, 1);
+            var inaugurationDay = new DateTime(year, 12, 1).Shift(-1, 1);
 
             var items = new List<PublicHoliday>();
             items.Add(new PublicHoliday(newYearDay, "Año Nuevo", "New Year's Day", countryCode));

--- a/Src/Nager.Date/PublicHolidays/MonacoProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/MonacoProvider.cs
@@ -29,7 +29,7 @@ namespace Nager.Date.PublicHolidays
             var countryCode = CountryCode.MC;
 
             var items = new List<PublicHoliday>();
-            
+
             items.Add(new PublicHoliday(year, 1, 27, "La Sainte Dévote", "Saint Devota's Day", countryCode));
             items.Add(this._catholicProvider.EasterMonday("Easter Monday", year, countryCode));
             items.Add(new PublicHoliday(year, 5, 1, "Le 1er mai", "May Day", countryCode));
@@ -41,28 +41,28 @@ namespace Nager.Date.PublicHolidays
 
             #region New Year's Day
 
-            var newYearsDay = new DateTime(year, 1, 1).Shift(saturday => saturday, sunday => sunday.AddDays(1));
+            var newYearsDay = new DateTime(year, 1, 1).Shift(0, 1);
             items.Add(new PublicHoliday(newYearsDay, "Le jour de l’An", "New Year's Day", countryCode));
 
             #endregion
 
             #region All Saints Day
 
-            var allSaintsDay = new DateTime(year, 11, 1).Shift(saturday => saturday, sunday => sunday.AddDays(1));
+            var allSaintsDay = new DateTime(year, 11, 1).Shift(0, 1);
             items.Add(new PublicHoliday(allSaintsDay, "La Toussaint", "All Saints Day", countryCode));
 
             #endregion
 
             #region National Day / La Fête du Prince
 
-            var nationalDay = new DateTime(year, 11, 19).Shift(saturday => saturday, sunday => sunday.AddDays(1));
+            var nationalDay = new DateTime(year, 11, 19).Shift(0, 1);
             items.Add(new PublicHoliday(nationalDay, "La Fête du Prince", "National Day", countryCode));
 
             #endregion
 
             #region Christmas Day
 
-            var christmasDay = new DateTime(year, 12, 25).Shift(saturday => saturday, sunday => sunday.AddDays(1));
+            var christmasDay = new DateTime(year, 12, 25).Shift(0, 1);
             items.Add(new PublicHoliday(christmasDay, "Noël​", "​Christmas Day", countryCode));
 
             #endregion

--- a/Src/Nager.Date/PublicHolidays/NewZealandProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/NewZealandProvider.cs
@@ -35,10 +35,10 @@ namespace Nager.Date.PublicHolidays
 
             #region New Year's Day with fallback
 
-            var newYearDay1 = new DateTime(year, 1, 1).Shift(saturday => saturday.AddDays(2), sunday => sunday.AddDays(1));
+            var newYearDay1 = new DateTime(year, 1, 1).Shift(2, 1);
             items.Add(new PublicHoliday(newYearDay1, "New Year's Day", "New Year's Day", countryCode));
 
-            var newYearDay2 = new DateTime(year, 1, 2).Shift(saturday => saturday.AddDays(2), sunday => sunday.AddDays(2));
+            var newYearDay2 = new DateTime(year, 1, 2).Shift(2, 2);
             items.Add(new PublicHoliday(newYearDay2, "Day after New Year's Day", "Day after New Year's Day", countryCode));
 
             #endregion
@@ -47,7 +47,7 @@ namespace Nager.Date.PublicHolidays
 
             if (year >= 2015)
             {
-                var anzacDay = new DateTime(year, 4, 25).Shift(saturday => saturday.AddDays(2), sunday => sunday.AddDays(1));
+                var anzacDay = new DateTime(year, 4, 25).Shift(2, 1);
                 items.Add(new PublicHoliday(anzacDay, "Anzac Day", "Anzac Day", countryCode));
             }
             else
@@ -61,7 +61,7 @@ namespace Nager.Date.PublicHolidays
 
             if (year >= 2016)
             {
-                var anzacDay = new DateTime(year, 2, 6).Shift(saturday => saturday.AddDays(2), sunday => sunday.AddDays(1));
+                var anzacDay = new DateTime(year, 2, 6).Shift(2, 1);
                 items.Add(new PublicHoliday(anzacDay, "Waitangi Day", "Waitangi Day", countryCode));
             }
             else
@@ -73,14 +73,14 @@ namespace Nager.Date.PublicHolidays
 
             #region Christmas Day with fallback
 
-            var christmasDay = new DateTime(year, 12, 25).Shift(saturday => saturday.AddDays(2), sunday => sunday.AddDays(1));
+            var christmasDay = new DateTime(year, 12, 25).Shift(2, 1);
             items.Add(new PublicHoliday(christmasDay, "Christmas Day", "Christmas Day", countryCode));
 
             #endregion
 
             #region Boxing Day with fallback
 
-            var boxingDay = new DateTime(year, 12, 26).Shift(saturday => saturday.AddDays(2), sunday => sunday.AddDays(2));
+            var boxingDay = new DateTime(year, 12, 26).Shift(2, 2);
             items.Add(new PublicHoliday(boxingDay, "Boxing Day", "Boxing Day", countryCode));
 
             #endregion

--- a/Src/Nager.Date/PublicHolidays/PuertoRicoProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/PuertoRicoProvider.cs
@@ -42,7 +42,7 @@ namespace Nager.Date.PublicHolidays
 
             #region New Years Day with fallback
 
-            var newYearsDay = new DateTime(year, 1, 1).Shift(saturday => saturday.AddDays(-1), sunday => sunday.AddDays(1));
+            var newYearsDay = new DateTime(year, 1, 1).Shift(-1, 1);
             items.Add(new PublicHoliday(newYearsDay, "Día de Año Nuevo", "New Year's Day", countryCode));
 
             #endregion
@@ -59,7 +59,7 @@ namespace Nager.Date.PublicHolidays
 
             #region Independence Day with fallback
 
-            var independenceDay = new DateTime(year, 7, 4).Shift(saturday => saturday.AddDays(-1), sunday => sunday.AddDays(1));
+            var independenceDay = new DateTime(year, 7, 4).Shift(-1, 1);
             items.Add(new PublicHoliday(independenceDay, "Día de la Independencia de los Estados Unidos", "Independence Day", countryCode));
 
             #endregion
@@ -72,7 +72,7 @@ namespace Nager.Date.PublicHolidays
 
             #region Veterans Day with fallback
 
-            var veteransDay = new DateTime(year, 11, 11).Shift(saturday => saturday.AddDays(-1), sunday => sunday.AddDays(1));
+            var veteransDay = new DateTime(year, 11, 11).Shift(-1, 1);
             items.Add(new PublicHoliday(veteransDay, "Día del Veterano Día del Armisticio", "Veterans Day", countryCode));
 
             #endregion

--- a/Src/Nager.Date/PublicHolidays/SouthKoreaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/SouthKoreaProvider.cs
@@ -1,4 +1,4 @@
-﻿using Nager.Date.Contract;
+using Nager.Date.Contract;
 using Nager.Date.Extensions;
 using Nager.Date.Model;
 using System;
@@ -25,17 +25,17 @@ namespace Nager.Date.PublicHolidays
                 var leapMonth = koreanCalendar.GetLeapMonth(year);
 
                 var lunarNewYear1 = koreanCalendar.ToDateTime(year, this.MoveMonth(1, leapMonth), 1, 0, 0, 0, 0); //Has substitute holiday
-                lunarNewYear1 = lunarNewYear1.Shift(saturday => saturday, sunday => sunday.AddDays(1));
+                lunarNewYear1 = lunarNewYear1.Shift(0, 1);
 
-                var lunarNewYear2 = lunarNewYear1.AddDays(+1).Shift(saturday => saturday, sunday => sunday.AddDays(1));
-                var lunarNewYear3 = lunarNewYear1.AddDays(-1).Shift(saturday => saturday, sunday => sunday.AddDays(-1));
+                var lunarNewYear2 = lunarNewYear1.AddDays(+1).Shift(0, 1);
+                var lunarNewYear3 = lunarNewYear1.AddDays(-1).Shift(0, -1);
 
                 var buddhaBday = koreanCalendar.ToDateTime(year, this.MoveMonth(4, leapMonth), 8, 0, 0, 0, 0);
 
                 var chuseok1 = koreanCalendar.ToDateTime(year, this.MoveMonth(8, leapMonth), 14, 0, 0, 0, 0); //Has substitute holiday
-                chuseok1 = chuseok1.Shift(saturday => saturday, sunday => sunday.AddDays(1));
-                var chuseok2 = chuseok1.AddDays(+1).Shift(saturday => saturday, sunday => sunday.AddDays(1));
-                var chuseok3 = chuseok2.AddDays(+1).Shift(saturday => saturday, sunday => sunday.AddDays(1));
+                chuseok1 = chuseok1.Shift(0, 1);
+                var chuseok2 = chuseok1.AddDays(+1).Shift(0, 1);
+                var chuseok3 = chuseok2.AddDays(+1).Shift(0, 1);
 
                 items.Add(new PublicHoliday(lunarNewYear1, "설날", "Lunar New Year", countryCode));
                 items.Add(new PublicHoliday(lunarNewYear2, "설날", "Lunar New Year", countryCode));
@@ -49,7 +49,7 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(year, 1, 1, "새해", "New Year's Day", countryCode));
             items.Add(new PublicHoliday(year, 3, 1, "3·1절", "Independence Movement Day", countryCode));
 
-            var childrenDay = new DateTime(year, 5, 5).Shift(saturday => saturday.AddDays(2), sunday => sunday.AddDays(1)); //Substitute holiday
+            var childrenDay = new DateTime(year, 5, 5).Shift(2, 1); //Substitute holiday
             items.Add(new PublicHoliday(childrenDay, "어린이날", "Children's Day", countryCode)); //Has substitute holiday
 
             items.Add(new PublicHoliday(year, 6, 6, "현충일", "Memorial Day", countryCode));

--- a/Src/Nager.Date/PublicHolidays/SpainProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/SpainProvider.cs
@@ -106,7 +106,7 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(year, 12, 8, "Inmaculada Concepción", "Immaculate Conception", countryCode));
             items.Add(new PublicHoliday(year, 12, 25, "Navidad", "Christmas Day", countryCode));
             items.Add(new PublicHoliday(year, 12, 26, "Sant Esteve", "St. Stephen's Day", countryCode, null, new string[] { "ES-CT" }));
-            
+
             var labourDay = this.LabourDay(year, countryCode);
             if (labourDay != null)
             {
@@ -130,14 +130,14 @@ namespace Nager.Date.PublicHolidays
 
         private PublicHoliday LabourDay(int year, CountryCode countryCode)
         {
-            var date = new DateTime(year, 5, 1).Shift(saturday => saturday, sunday => sunday.AddDays(1));
+            var date = new DateTime(year, 5, 1).Shift(0, 1);
 
             return new PublicHoliday(date, "Fiesta del trabajo", "Labour Day", countryCode);
         }
 
         private PublicHoliday DayOfMadrid(int year, CountryCode countryCode, PublicHoliday labourDay)
         {
-            var date = new DateTime(year, 5, 2).Shift(saturday => saturday, sunday => sunday.AddDays(1));
+            var date = new DateTime(year, 5, 2).Shift(0, 1);
             if (labourDay.Date == date)
             {
                 date = date.AddDays(1);
@@ -148,7 +148,7 @@ namespace Nager.Date.PublicHolidays
 
         private PublicHoliday Assumption(int year, CountryCode countryCode)
         {
-            var date = new DateTime(year, 8, 15).Shift(saturday => saturday, sunday => sunday.AddDays(1));
+            var date = new DateTime(year, 8, 15).Shift(0, 1);
 
             return new PublicHoliday(date, "Asunción", "Assumption", countryCode);
         }

--- a/Src/Nager.Date/PublicHolidays/UnitedKingdomProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/UnitedKingdomProvider.cs
@@ -57,7 +57,7 @@ namespace Nager.Date.PublicHolidays
 
             #region New Year's Day 2 with fallback
 
-            var newYearDay2 = new DateTime(year, 1, 2).Shift(saturday => saturday.AddDays(2), sunday => sunday.AddDays(1));
+            var newYearDay2 = new DateTime(year, 1, 2).Shift(2, 1);
             items.Add(new PublicHoliday(newYearDay2, "New Year's Day", "New Year's Day", countryCode, null, new string[] { "GB-SCT" }));
 
             #endregion
@@ -90,14 +90,14 @@ namespace Nager.Date.PublicHolidays
 
             #region Christmas Day with fallback
 
-            var christmasDay = new DateTime(year, 12, 25).Shift(saturday => saturday.AddDays(2), sunday => sunday.AddDays(2));
+            var christmasDay = new DateTime(year, 12, 25).Shift(2, 2);
             items.Add(new PublicHoliday(christmasDay, "Christmas Day", "Christmas Day", countryCode));
 
             #endregion
 
             #region St. Stephen's Day with fallback
 
-            var sanktStehpenDay = new DateTime(year, 12, 26).Shift(saturday => saturday.AddDays(2), sunday => sunday.AddDays(2));
+            var sanktStehpenDay = new DateTime(year, 12, 26).Shift(2, 2);
             items.Add(new PublicHoliday(sanktStehpenDay, "Boxing Day", "St. Stephen's Day", countryCode));
 
             #endregion

--- a/Src/Nager.Date/PublicHolidays/UnitedStatesProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/UnitedStatesProvider.cs
@@ -35,7 +35,7 @@ namespace Nager.Date.PublicHolidays
 
             #region New Years Day with fallback
 
-            var newYearsDay = new DateTime(year, 1, 1).Shift(saturday => saturday.AddDays(-1), sunday => sunday.AddDays(1));
+            var newYearsDay = new DateTime(year, 1, 1).Shift(-1, 1);
             items.Add(new PublicHoliday(newYearsDay, "New Year's Day", "New Year's Day", countryCode));
 
             #endregion
@@ -46,7 +46,7 @@ namespace Nager.Date.PublicHolidays
 
             #region Independence Day with fallback
 
-            var independenceDay = new DateTime(year, 7, 4).Shift(saturday => saturday.AddDays(-1), sunday => sunday.AddDays(1));
+            var independenceDay = new DateTime(year, 7, 4).Shift(-1, 1);
             items.Add(new PublicHoliday(independenceDay, "Independence Day", "Independence Day", countryCode));
 
             #endregion
@@ -56,7 +56,7 @@ namespace Nager.Date.PublicHolidays
 
             #region Veterans Day with fallback
 
-            var veteransDay = new DateTime(year, 11, 11).Shift(saturday => saturday.AddDays(-1), sunday => sunday.AddDays(1));
+            var veteransDay = new DateTime(year, 11, 11).Shift(-1, 1);
             items.Add(new PublicHoliday(veteransDay, "Veterans Day", "Veterans Day", countryCode));
 
             #endregion
@@ -65,7 +65,7 @@ namespace Nager.Date.PublicHolidays
 
             #region Christmas Day with fallback
 
-            var christmasDay = new DateTime(year, 12, 25).Shift(saturday => saturday.AddDays(-1), sunday => sunday.AddDays(1));
+            var christmasDay = new DateTime(year, 12, 25).Shift(-1, 1);
             items.Add(new PublicHoliday(christmasDay, "Christmas Day", "Christmas Day", countryCode));
 
             #endregion


### PR DESCRIPTION
This is a small performance gain / maintainability refactoring. It is mainly used to improve the usage of `.Shift()` and `.ShiftWeekdays()`.