### PR TITLE
Fix Costa Rica public holidays

### DIFF
--- a/Src/Nager.Date/PublicHolidays/CostaRicaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/CostaRicaProvider.cs
@@ -27,17 +27,17 @@ namespace Nager.Date.PublicHolidays
             var countryCode = CountryCode.CR;
 
             var items = new List<PublicHoliday>();
-            items.Add(new PublicHoliday(year, 1, 1, "New Year's Day", "New Year's Day", countryCode));
-            items.Add(new PublicHoliday(year, 4, 11, "Juan Santa maria Day", "Juan Santa maria Day", countryCode));
-            items.Add(this._catholicProvider.MaundyThursday("Good Thursday", year, countryCode));
-            items.Add(this._catholicProvider.GoodFriday("Good Friday", year, countryCode));
-            items.Add(new PublicHoliday(year, 5, 1, "Labor Day", "Labor Day", countryCode));
-            items.Add(new PublicHoliday(year, 7, 25, "Guanacaste Day", "Guanacaste Day", countryCode));
-            items.Add(new PublicHoliday(year, 8, 2, "Virgin of Los Angeles Day", "Virgin of Los Angeles Day", countryCode));
-            items.Add(new PublicHoliday(year, 8, 15, "Mother´s Day", "Mother´s Day", countryCode));
-            items.Add(new PublicHoliday(year, 9, 15, "Independence Day", "Independence Day", countryCode));
-            items.Add(new PublicHoliday(year, 10, 12, "Cultures National Day", "Cultures National Day", countryCode));
-            items.Add(new PublicHoliday(year, 12, 25, "Christmas Day", "Christmas Day", countryCode));
+            items.Add(new PublicHoliday(year, 1, 1, "Año Nuevo", "New Year's Day", countryCode));
+            items.Add(new PublicHoliday(year, 4, 11, "Día de Juan Santamaría", "Juan Santamaría Day", countryCode));
+            items.Add(this._catholicProvider.MaundyThursday("Jueves Santo", year, countryCode));
+            items.Add(this._catholicProvider.GoodFriday("Viernes Santo", year, countryCode));
+            items.Add(new PublicHoliday(year, 5, 1, "Día Internacional del Trabajo", "Labour Day", countryCode));
+            items.Add(new PublicHoliday(year, 7, 25, "Anexión del Partido de Nicoya a Costa Rica", "Annexation of the Party of Nicoya to Costa Rica", countryCode));
+            items.Add(new PublicHoliday(year, 8, 2, "Fiesta de Nuestra Señora de los Ángeles", "Feast of Our Lady of the Angels", countryCode));
+            items.Add(new PublicHoliday(year, 8, 15, "Día de la Madre", "Mother's Day", countryCode));
+            items.Add(new PublicHoliday(year, 9, 15, "Día de la Independencia", "Independence Day", countryCode));
+            items.Add(new PublicHoliday(year, 12, 1, "Día de la Abolición del Ejército", "Army Abolition Day", countryCode));
+            items.Add(new PublicHoliday(year, 12, 25, "Navidad", "Christmas Day", countryCode));
 
             return items.OrderBy(o => o.Date);
         }

--- a/Src/Nager.Date/PublicHolidays/CostaRicaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/CostaRicaProvider.cs
@@ -1,5 +1,7 @@
 using Nager.Date.Contract;
+using Nager.Date.Extensions;
 using Nager.Date.Model;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -28,16 +30,25 @@ namespace Nager.Date.PublicHolidays
 
             var items = new List<PublicHoliday>();
             items.Add(new PublicHoliday(year, 1, 1, "Año Nuevo", "New Year's Day", countryCode));
-            items.Add(new PublicHoliday(year, 4, 11, "Día de Juan Santamaría", "Juan Santamaría Day", countryCode));
             items.Add(this._catholicProvider.MaundyThursday("Jueves Santo", year, countryCode));
             items.Add(this._catholicProvider.GoodFriday("Viernes Santo", year, countryCode));
-            items.Add(new PublicHoliday(year, 5, 1, "Día Internacional del Trabajo", "Labour Day", countryCode));
-            items.Add(new PublicHoliday(year, 7, 25, "Anexión del Partido de Nicoya a Costa Rica", "Annexation of the Party of Nicoya to Costa Rica", countryCode));
             items.Add(new PublicHoliday(year, 8, 2, "Fiesta de Nuestra Señora de los Ángeles", "Feast of Our Lady of the Angels", countryCode));
-            items.Add(new PublicHoliday(year, 8, 15, "Día de la Madre", "Mother's Day", countryCode));
-            items.Add(new PublicHoliday(year, 9, 15, "Día de la Independencia", "Independence Day", countryCode));
-            items.Add(new PublicHoliday(year, 12, 1, "Día de la Abolición del Ejército", "Army Abolition Day", countryCode));
             items.Add(new PublicHoliday(year, 12, 25, "Navidad", "Christmas Day", countryCode));
+            items.Add(GetJuanSantamariaDay(year, countryCode));
+            items.Add(GetLabourDay(year, countryCode));
+            items.Add(GetAnnexationDay(year, countryCode));            
+            items.Add(GetMothersDay(year, countryCode));
+            items.Add(GetIndenpendenceDay(year, countryCode));            
+
+            //Law 9803
+            if (year >= 2020)
+            {
+                items.Add(GetArmyAbolitionDay(year, countryCode));
+            }
+            else
+            {
+                items.Add(new PublicHoliday(year, 10, 12, "Día de las Culturas", "Cultures Day", countryCode));
+            }
 
             return items.OrderBy(o => o.Date);
         }
@@ -49,6 +60,68 @@ namespace Nager.Date.PublicHolidays
             {
                 "https://en.wikipedia.org/wiki/Public_holidays_in_Costa_Rica",
             };
+        }
+
+        private PublicHoliday GetJuanSantamariaDay(int year, CountryCode countryCode)
+        {
+            var juanSantamariaDay = new DateTime(year, 4, 11);
+            ApplyLaw9875Shift(ref juanSantamariaDay, exceptionYears: new int[] { 2020, 2021 });
+
+            return new PublicHoliday(juanSantamariaDay, "Día de Juan Santamaría", "Juan Santamaría Day", countryCode);
+        }
+
+        private PublicHoliday GetLabourDay(int year, CountryCode countryCode)
+        {
+            var labourDay = new DateTime(year, 5, 1);
+            ApplyLaw9875Shift(ref labourDay, exceptionYears: new int[] { 2022, 2024 });
+
+            return new PublicHoliday(labourDay, "Día Internacional del Trabajo", "Labour Day", countryCode);
+        }
+
+        private PublicHoliday GetAnnexationDay(int year, CountryCode countryCode)
+        {
+            var annexationDay = new DateTime(year, 7, 25);
+            ApplyLaw9875Shift(ref annexationDay);
+
+            return new PublicHoliday(annexationDay, "Anexión del Partido de Nicoya a Costa Rica", "Annexation of the Party of Nicoya to Costa Rica", countryCode);
+        }
+
+        private PublicHoliday GetMothersDay(int year, CountryCode countryCode)
+        {
+            var mothersDay = new DateTime(year, 8, 15);
+            ApplyLaw9875Shift(ref mothersDay, exceptionYears: new int[] { 2021 });
+
+            return new PublicHoliday(mothersDay, "Día de la Madre", "Mother's Day", countryCode);
+        }
+
+        private PublicHoliday GetIndenpendenceDay(int year, CountryCode countryCode)
+        {
+            var indenpendenceDay = new DateTime(year, 9, 15);
+            ApplyLaw9875Shift(ref indenpendenceDay, exceptionYears: new int[] { 2024 });
+
+            return new PublicHoliday(indenpendenceDay, "Día de la Independencia", "Independence Day", countryCode);
+        }
+
+        private PublicHoliday GetArmyAbolitionDay(int year, CountryCode countryCode)
+        {
+            var armyAbolitionDay = new DateTime(year, 12, 1);
+            ApplyLaw9875Shift(ref armyAbolitionDay, exceptionYears: new int[] { 2024 });
+
+            return new PublicHoliday(armyAbolitionDay, "Día de la Abolición del Ejército", "Army Abolition Day", countryCode);
+        }
+
+        private void ApplyLaw9875Shift(ref DateTime date, IEnumerable<int> exceptionYears = null)
+        {
+            var applicableYears = new int[] { 2020, 2021, 2022, 2023, 2024 };
+            if (applicableYears.Contains(date.Year) && (exceptionYears == null || !exceptionYears.Contains(date.Year)))
+            {
+                date = date.Shift(saturday: saturday => saturday.AddDays(2), sunday: sunday => sunday.AddDays(1));
+                date = date.ShiftWeekdays(
+                    tuesday: tuesday => tuesday.AddDays(-1),
+                    wednesday: wednesday => wednesday.AddDays(-2),
+                    thursday: thursday => thursday.AddDays(4)
+                    );
+            }
         }
     }
 }

--- a/Src/Nager.Date/PublicHolidays/CostaRicaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/CostaRicaProvider.cs
@@ -113,7 +113,7 @@ namespace Nager.Date.PublicHolidays
         private void ApplyLaw9875Shift(ref DateTime date, IEnumerable<int> exceptionYears = default)
         {
             var applicableYears = new int[] { 2020, 2021, 2022, 2023, 2024 };
-            if (applicableYears.Contains(date.Year) && (exceptionYears == null || !exceptionYears.Contains(date.Year)))
+            if ((exceptionYears == null || !exceptionYears.Contains(date.Year)) && applicableYears.Contains(date.Year))
             {
                 date = date.Shift(saturday: saturday => saturday.AddDays(2), sunday: sunday => sunday.AddDays(1));
                 date = date.ShiftWeekdays(

--- a/Src/Nager.Date/PublicHolidays/CostaRicaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/CostaRicaProvider.cs
@@ -65,7 +65,10 @@ namespace Nager.Date.PublicHolidays
         private PublicHoliday GetJuanSantamariaDay(int year, CountryCode countryCode)
         {
             var juanSantamariaDay = new DateTime(year, 4, 11);
-            ApplyLaw9875Shift(ref juanSantamariaDay, exceptionYears: new int[] { 2020, 2021, 2022 });
+            if (year == 2023 || year == 2024)
+            {
+                juanSantamariaDay = ApplyLaw9875Shift(juanSantamariaDay);
+            }
 
             return new PublicHoliday(juanSantamariaDay, "Día de Juan Santamaría", "Juan Santamaría Day", countryCode);
         }
@@ -73,7 +76,10 @@ namespace Nager.Date.PublicHolidays
         private PublicHoliday GetLabourDay(int year, CountryCode countryCode)
         {
             var labourDay = new DateTime(year, 5, 1);
-            ApplyLaw9875Shift(ref labourDay, exceptionYears: new int[] { 2020, 2022, 2023, 2024 });
+            if (year == 2021)
+            {
+                labourDay = ApplyLaw9875Shift(labourDay);
+            }
 
             return new PublicHoliday(labourDay, "Día Internacional del Trabajo", "Labour Day", countryCode);
         }
@@ -81,7 +87,10 @@ namespace Nager.Date.PublicHolidays
         private PublicHoliday GetAnnexationDay(int year, CountryCode countryCode)
         {
             var annexationDay = new DateTime(year, 7, 25);
-            ApplyLaw9875Shift(ref annexationDay, exceptionYears: new int[] { 2022 });
+            if (year == 2020 || year == 2021 || year == 2023 || year == 2024)
+            {
+                annexationDay = ApplyLaw9875Shift(annexationDay);
+            }
 
             return new PublicHoliday(annexationDay, "Anexión del Partido de Nicoya a Costa Rica", "Annexation of the Party of Nicoya to Costa Rica", countryCode);
         }
@@ -89,7 +98,10 @@ namespace Nager.Date.PublicHolidays
         private PublicHoliday GetMothersDay(int year, CountryCode countryCode)
         {
             var mothersDay = new DateTime(year, 8, 15);
-            ApplyLaw9875Shift(ref mothersDay, exceptionYears: new int[] { 2021, 2022 });
+            if (year == 2020 || year == 2023 || year == 2024)
+            {
+                mothersDay = ApplyLaw9875Shift(mothersDay);
+            }
 
             return new PublicHoliday(mothersDay, "Día de la Madre", "Mother's Day", countryCode);
         }
@@ -97,7 +109,10 @@ namespace Nager.Date.PublicHolidays
         private PublicHoliday GetIndenpendenceDay(int year, CountryCode countryCode)
         {
             var indenpendenceDay = new DateTime(year, 9, 15);
-            ApplyLaw9875Shift(ref indenpendenceDay, exceptionYears: new int[] { 2023, 2024 });
+            if (year == 2020 || year == 2021 || year == 2022)
+            {
+                indenpendenceDay = ApplyLaw9875Shift(indenpendenceDay);
+            }
 
             return new PublicHoliday(indenpendenceDay, "Día de la Independencia", "Independence Day", countryCode);
         }
@@ -105,23 +120,23 @@ namespace Nager.Date.PublicHolidays
         private PublicHoliday GetArmyAbolitionDay(int year, CountryCode countryCode)
         {
             var armyAbolitionDay = new DateTime(year, 12, 1);
-            ApplyLaw9875Shift(ref armyAbolitionDay, exceptionYears: new int[] { 2023, 2024 });
+            if (year == 2020 || year == 2021 || year == 2022)
+            {
+                armyAbolitionDay = ApplyLaw9875Shift(armyAbolitionDay);
+            }
 
             return new PublicHoliday(armyAbolitionDay, "Día de la Abolición del Ejército", "Army Abolition Day", countryCode);
         }
 
-        private void ApplyLaw9875Shift(ref DateTime date, IEnumerable<int> exceptionYears = default)
+        private DateTime ApplyLaw9875Shift(DateTime date)
         {
-            var applicableYears = new int[] { 2020, 2021, 2022, 2023, 2024 };
-            if ((exceptionYears == null || !exceptionYears.Contains(date.Year)) && applicableYears.Contains(date.Year))
-            {
-                date = date.Shift(saturday: saturday => saturday.AddDays(2), sunday: sunday => sunday.AddDays(1));
-                date = date.ShiftWeekdays(
-                    tuesday: tuesday => tuesday.AddDays(-1),
-                    wednesday: wednesday => wednesday.AddDays(-2),
-                    thursday: thursday => thursday.AddDays(4)
-                    );
-            }
+            date = date.Shift(saturday: saturday => saturday.AddDays(2), sunday: sunday => sunday.AddDays(1));
+            date = date.ShiftWeekdays(
+                tuesday: tuesday => tuesday.AddDays(-1),
+                wednesday: wednesday => wednesday.AddDays(-2),
+                thursday: thursday => thursday.AddDays(4)
+                );
+            return date;
         }
     }
 }

--- a/Src/Nager.Date/PublicHolidays/CostaRicaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/CostaRicaProvider.cs
@@ -65,7 +65,7 @@ namespace Nager.Date.PublicHolidays
         private PublicHoliday GetJuanSantamariaDay(int year, CountryCode countryCode)
         {
             var juanSantamariaDay = new DateTime(year, 4, 11);
-            ApplyLaw9875Shift(ref juanSantamariaDay, exceptionYears: new int[] { 2020, 2021 });
+            ApplyLaw9875Shift(ref juanSantamariaDay, exceptionYears: new int[] { 2020, 2021, 2022 });
 
             return new PublicHoliday(juanSantamariaDay, "Día de Juan Santamaría", "Juan Santamaría Day", countryCode);
         }
@@ -73,7 +73,7 @@ namespace Nager.Date.PublicHolidays
         private PublicHoliday GetLabourDay(int year, CountryCode countryCode)
         {
             var labourDay = new DateTime(year, 5, 1);
-            ApplyLaw9875Shift(ref labourDay, exceptionYears: new int[] { 2022, 2024 });
+            ApplyLaw9875Shift(ref labourDay, exceptionYears: new int[] { 2020, 2022, 2023, 2024 });
 
             return new PublicHoliday(labourDay, "Día Internacional del Trabajo", "Labour Day", countryCode);
         }
@@ -81,7 +81,7 @@ namespace Nager.Date.PublicHolidays
         private PublicHoliday GetAnnexationDay(int year, CountryCode countryCode)
         {
             var annexationDay = new DateTime(year, 7, 25);
-            ApplyLaw9875Shift(ref annexationDay);
+            ApplyLaw9875Shift(ref annexationDay, exceptionYears: new int[] { 2022 });
 
             return new PublicHoliday(annexationDay, "Anexión del Partido de Nicoya a Costa Rica", "Annexation of the Party of Nicoya to Costa Rica", countryCode);
         }
@@ -89,7 +89,7 @@ namespace Nager.Date.PublicHolidays
         private PublicHoliday GetMothersDay(int year, CountryCode countryCode)
         {
             var mothersDay = new DateTime(year, 8, 15);
-            ApplyLaw9875Shift(ref mothersDay, exceptionYears: new int[] { 2021 });
+            ApplyLaw9875Shift(ref mothersDay, exceptionYears: new int[] { 2021, 2022 });
 
             return new PublicHoliday(mothersDay, "Día de la Madre", "Mother's Day", countryCode);
         }
@@ -97,7 +97,7 @@ namespace Nager.Date.PublicHolidays
         private PublicHoliday GetIndenpendenceDay(int year, CountryCode countryCode)
         {
             var indenpendenceDay = new DateTime(year, 9, 15);
-            ApplyLaw9875Shift(ref indenpendenceDay, exceptionYears: new int[] { 2024 });
+            ApplyLaw9875Shift(ref indenpendenceDay, exceptionYears: new int[] { 2023, 2024 });
 
             return new PublicHoliday(indenpendenceDay, "Día de la Independencia", "Independence Day", countryCode);
         }
@@ -105,12 +105,12 @@ namespace Nager.Date.PublicHolidays
         private PublicHoliday GetArmyAbolitionDay(int year, CountryCode countryCode)
         {
             var armyAbolitionDay = new DateTime(year, 12, 1);
-            ApplyLaw9875Shift(ref armyAbolitionDay, exceptionYears: new int[] { 2024 });
+            ApplyLaw9875Shift(ref armyAbolitionDay, exceptionYears: new int[] { 2023, 2024 });
 
             return new PublicHoliday(armyAbolitionDay, "Día de la Abolición del Ejército", "Army Abolition Day", countryCode);
         }
 
-        private void ApplyLaw9875Shift(ref DateTime date, IEnumerable<int> exceptionYears = null)
+        private void ApplyLaw9875Shift(ref DateTime date, IEnumerable<int> exceptionYears = default)
         {
             var applicableYears = new int[] { 2020, 2021, 2022, 2023, 2024 };
             if (applicableYears.Contains(date.Year) && (exceptionYears == null || !exceptionYears.Contains(date.Year)))


### PR DESCRIPTION
- Fix Costa Rica holidays
Cultures National Day no longer a holiday, it was replaced with the Army Abolition Day

- Fix names and add local names