### PR TITLE
The Federal Day of Thanksgiving is an official public holiday only in the canton of Vaud

### DIFF
--- a/Src/Nager.Date/PublicHolidays/SwitzerlandProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/SwitzerlandProvider.cs
@@ -83,7 +83,7 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(year, 12, 26, "Stephanstag", "St. Stephen's Day", countryCode, null, new string[] { "CH-AG", "CH-AI", "CH-AR", "CH-BL", "CH-BS", "CH-BE", "CH-FR", "CH-GL", "CH-GR", "CH-LU", "CH-NW", "CH-OW", "CH-SG", "CH-SH", "CH-SZ", "CH-SO", "CH-TG", "CH-TI", "CH-UR", "CH-ZG", "CH-ZH" }));
 
             items.Add(new PublicHoliday(firstSundayOfSeptember.AddDays(4), "Jeûne genevois", "Geneva Prayday", countryCode, null, new string[] { "CH-GE" }));
-            items.Add(new PublicHoliday(thirdMondayOfSeptember, "Eidgenössischer Dank-, Buss- und Bettag", "Federal Day of Thanksgiving", countryCode, null, new string[] { "CH-ZH", "CH-BE", "CH-LU", "CH-UR", "CH-SZ", "CH-OW", "CH-NW", "CH-GL", "CH-ZG", "CH-FR", "CH-SO", "CH-BS", "CH-BL", "CH-SH", "CH-AR", "CH-AI", "CH-SG", "CH-GR", "CH-AG", "CH-TG", "CH-TI", "CH-VD", "CH-VS", "CH-NE", "CH-JU" }));
+            items.Add(new PublicHoliday(thirdMondayOfSeptember, "Lundi du Jeûne", "Prayer Monday", countryCode, null, new string[] { "CH-VD" }));
 
             return items.OrderBy(o => o.Date);
         }

--- a/Src/Nager.Date/PublicHolidays/SwitzerlandProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/SwitzerlandProvider.cs
@@ -83,7 +83,7 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(year, 12, 26, "Stephanstag", "St. Stephen's Day", countryCode, null, new string[] { "CH-AG", "CH-AI", "CH-AR", "CH-BL", "CH-BS", "CH-BE", "CH-FR", "CH-GL", "CH-GR", "CH-LU", "CH-NW", "CH-OW", "CH-SG", "CH-SH", "CH-SZ", "CH-SO", "CH-TG", "CH-TI", "CH-UR", "CH-ZG", "CH-ZH" }));
 
             items.Add(new PublicHoliday(firstSundayOfSeptember.AddDays(4), "Jeûne genevois", "Geneva Prayday", countryCode, null, new string[] { "CH-GE" }));
-            items.Add(new PublicHoliday(thirdMondayOfSeptember, "Lundi du Jeûne", "Prayer Monday", countryCode, null, new string[] { "CH-VD" }));
+            items.Add(new PublicHoliday(thirdMondayOfSeptember, "Lundi du Jeûne", "Federal Day of Thanksgiving", countryCode, null, new string[] { "CH-VD" }));
 
             return items.OrderBy(o => o.Date);
         }


### PR DESCRIPTION
First of all thank you for providing such an amazing API.

The Federal Day of Thanksgiving is an official public holiday only in the canton of Vaud, in other cantons it's not the case.

As Vaud is a french speaking canton I also changed the name to "Lundi du Jeûne"

Here are the Wikipedia pages: 
https://en.wikipedia.org/wiki/Federal_Day_of_Thanksgiving,_Repentance_and_Prayer
https://en.wikipedia.org/wiki/Public_holidays_in_Switzerland

And a screenshot from Google calendar to confirm.

![image](https://user-images.githubusercontent.com/23431411/132092899-29631078-27b1-4b08-9d89-afce48dd8791.png)

