### PR TITLE
feat: add automated release management

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -6,9 +6,11 @@ on:
     - 'src/**'
     - '.github/workflows/**'
     branches: [ master ]
+  release:
+    types:
+    - created
 
 jobs:
-
   build:
 
     runs-on: ubuntu-latest
@@ -16,6 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Build the Docker image
+      if: github.event_name == 'push'
       env:
         DOCKER_TAG_PREFIX: dev
       run: |
@@ -23,4 +26,11 @@ jobs:
         docker build . --file Dockerfile --tag nager/nager-date:$DOCKER_TAG_PREFIX-$GITHUB_RUN_NUMBER --tag nager/nager-date:latest
         docker push nager/nager-date:$DOCKER_TAG_PREFIX-$GITHUB_RUN_NUMBER
         docker push nager/nager-date:latest
-        
+
+    - name: Build the Docker release image
+      if: github.event_name == 'release'
+      run: |
+        DOCKER_TAG=${GITHUB_REF##*/}
+        docker login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }}
+        docker build . --file Dockerfile --tag nager/nager-date:$DOCKER_TAG
+        docker push nager/nager-date:$DOCKER_TAG

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    name: "Release"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2.3.4
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v2
+        with:
+          extra_plugins: |
+            @semantic-release/changelog
+            @semantic-release/git
+            @semantic-release/exec
+        env:
+          GH_TOKEN: ${{ secret.PERSONAL_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,20 @@
+{
+    "branches": [
+        "master"
+    ],
+    "repositoryUrl": "https://github.com/nager/Nager.Date.git",
+    "tagFormat": "${version}",
+    "plugins": [
+       "@semantic-release/commit-analyzer",
+       ["@semantic-release/exec", {
+		"prepareCmd": "sed -i \"s/<Version>.*<\\\/Version>/<Version>${nextRelease.version}<\\\/Version>/g\" src/Nager.Date/Nager.Date.csproj"
+       }],
+       "@semantic-release/release-notes-generator",
+       "@semantic-release/changelog",
+       ["@semantic-release/git", {
+          "assets": ["src/Nager.Date/Nager.Date.csproj", "CHANGELOG.md"],
+          "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
+       }],
+       "@semantic-release/github"
+    ]
+}


### PR DESCRIPTION
This PR will leverage [semantic release](https://github.com/semantic-release/semantic-release) in order to automate tagging and changelog management and hopefully fixes #308.

Before merging this PR, the maintainer will need to create a github secret `PERSONAL_TOKEN` containing a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-token). Without this token set, the github action that will create the tag and commit the changelog and csproj files won't trigger the docker build with the embedded updates.
Maintainer will also have to create a proper `1.30.0` tag or semantic release will start from the `1.25.0` version.

From there on, contributors and maintainers will just have to follow the [semantic release commit message convention](https://github.com/semantic-release/semantic-release#how-does-it-work).
