### PR TITLE
CORS with ratelimiting

### DIFF
--- a/src/Nager.Date.Website/Nager.Date.Website.csproj
+++ b/src/Nager.Date.Website/Nager.Date.Website.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCoreRateLimit" Version="3.2.2" />
+    <PackageReference Include="AspNetCoreRateLimit" Version="4.0.1" />
     <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
     <PackageReference Include="CsvHelper" Version="26.0.1" />
     <PackageReference Include="Mapster" Version="7.1.5" />

--- a/src/Nager.Date.Website/appsettings.json
+++ b/src/Nager.Date.Website/appsettings.json
@@ -6,14 +6,14 @@
   },
   "AllowedHosts": "*",
   "EnableIpRateLimiting": true,
-  "EnableCors": false,
+  "EnableCors": true,
   "EnableSwaggerMode": false,
   "IpRateLimiting": {
     "EnableEndpointRateLimiting": false,
     "StackBlockedRequests": false,
     "HttpStatusCode": 429,
     "EndpointWhitelist": [ "*:/home/*", "*:/publicholiday/*", "*:/sitemap/*", "*:/css/*", "*:/lib/*", "*:/images/*", "*:/favicon.ico", "*:/" ],
-    "IpWhitelist": [ "127.0.0.1" ],
+    "IpWhitelist": [ "127.0.0.1", "::1/10" ],
     "GeneralRules": [
       {
         "Endpoint": "*",
@@ -22,8 +22,8 @@
       },
       {
         "Endpoint": "*",
-        "Period": "1h",
-        "Limit": 100
+        "Period": "1d",
+        "Limit": 50
       }
     ]
   }


### PR DESCRIPTION
Thanks for the great library. 
The https://date.nager.at/ site itself appears like it serves as a low volume API endpoint, but it is obviously currently set up to __not__ set the appropriate `Access-Control-Allow-Origin` header for CORS requests. Looking at the library it is obvious if hosting myself I could set this up, but there were a few changes which might be worth considering - implemented here:

1. App settings changed to fit documented limit of 50 requests per day per IP (see project Readme) as opposed to 100 per hour
2. IpWhitelist changed to include in the whitelist all API requests made from a browser viewing the MVC site (when running on a development server - "::1/10")
3. AspNetCoreRateLimit to v 4.0.1 as problem solving this anyway
4. Restrict CORS to GET requests - put/delete etc should not be CORS
5. move call to `UseCors` to between `UseRouting` and `UseEndpoints` as per microsoft documentation (comments included to the same effect)