### PR TITLE
Fix Isle of Man Bank Holidays

### DIFF
--- a/src/Nager.Date.UnitTest/Country/IsleOfManTest.cs
+++ b/src/Nager.Date.UnitTest/Country/IsleOfManTest.cs
@@ -1,0 +1,140 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Nager.Date.Extensions;
+using System;
+
+namespace Nager.Date.UnitTest.Country
+{
+    [TestClass]
+    public class IsleOfManTest
+    {
+        [TestMethod]
+        public void TestIsleOfMan()
+        {
+            var testDate = new DateTime(2017, 08, 28);
+            var isPublicHoliday = DateSystem.IsPublicHoliday(testDate, CountryCode.IM);
+            Assert.AreEqual(true, isPublicHoliday);
+        }
+
+        [TestMethod]
+        [DataRow(2015, 5, 4, true)]
+        [DataRow(2016, 5, 2, true)]
+        [DataRow(2017, 5, 1, true)]
+        [DataRow(2018, 5, 7, true)]
+        [DataRow(2019, 5, 6, true)]
+        [DataRow(2020, 5, 1, false)]
+        [DataRow(2020, 5, 4, false)]
+        [DataRow(2020, 5, 8, true)]
+        [DataRow(2021, 5, 3, true)]
+        [DataRow(2022, 5, 2, true)]
+        public void CheckEarlyMayDay(int year, int month, int day, bool expected)
+        {
+            var date = new DateTime(year, month, day);
+
+            var result = DateSystem.IsPublicHoliday(date, CountryCode.IM);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        [DataRow(2015, 5, 25, true)]
+        [DataRow(2016, 5, 30, true)]
+        [DataRow(2017, 5, 29, true)]
+        [DataRow(2018, 5, 28, true)]
+        [DataRow(2019, 5, 27, true)]
+        [DataRow(2020, 5, 25, true)]
+        [DataRow(2021, 5, 31, true)]
+        [DataRow(2022, 6, 2, true)]
+        public void CheckLateMaySpringDay(int year, int month, int day, bool expected)
+        {
+            var date = new DateTime(year, month, day);
+
+            var result = DateSystem.IsPublicHoliday(date, CountryCode.IM);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        [DataRow(2015, 6, 12, true)]
+        [DataRow(2016, 6, 10, true)]
+        [DataRow(2017, 6, 9, true)]
+        [DataRow(2018, 6, 8, true)]
+        [DataRow(2019, 6, 7, true)]
+        [DataRow(2020, 6, 12, false)]
+        [DataRow(2020, 8, 28, true)]
+        [DataRow(2021, 6, 11, true)]
+        [DataRow(2022, 6, 10, true)]
+        public void CheckTTRaceDay(int year, int month, int day, bool expected)
+        {
+            var date = new DateTime(year, month, day);
+
+            var result = DateSystem.IsPublicHoliday(date, CountryCode.IM);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        [DataRow(2015, 7, 6, true)]
+        [DataRow(2016, 7, 5, true)]
+        [DataRow(2017, 7, 5, true)]
+        [DataRow(2018, 7, 5, true)]
+        [DataRow(2019, 7, 5, true)]
+        [DataRow(2020, 7, 6, true)]
+        [DataRow(2021, 7, 5, true)]
+        [DataRow(2022, 7, 5, true)]
+        public void CheckTynwaldDay(int year, int month, int day, bool expected)
+        {
+            var date = new DateTime(year, month, day);
+
+            var result = DateSystem.IsPublicHoliday(date, CountryCode.IM);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        [DataRow(2015, 8, 31, true)]
+        [DataRow(2016, 8, 29, true)]
+        [DataRow(2017, 8, 28, true)]
+        [DataRow(2018, 8, 27, true)]
+        [DataRow(2019, 8, 26, true)]
+        [DataRow(2020, 8, 31, true)]
+        [DataRow(2021, 8, 30, true)]
+        [DataRow(2022, 8, 29, true)]
+        public void CheckSummerDay(int year, int month, int day, bool expected)
+        {
+            var date = new DateTime(year, month, day);
+
+            var result = DateSystem.IsPublicHoliday(date, CountryCode.IM);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        [DataRow(2015, 12, 25, 28)]
+        [DataRow(2016, 12, 27, 26)]
+        [DataRow(2017, 12, 25, 26)]
+        [DataRow(2018, 12, 25, 26)]
+        [DataRow(2019, 12, 25, 26)]
+        [DataRow(2020, 12, 25, 28)]
+        [DataRow(2021, 12, 27, 28)]
+        [DataRow(2022, 12, 27, 26)]
+        public void CheckChristmasDayAndBoxingDay(int year, int month, int expectedChristmasDay, int expectedBoxingDay)
+        {
+            Assert.IsTrue(DateSystem.IsPublicHoliday(new DateTime(year, month, expectedChristmasDay), CountryCode.IM));
+            Assert.IsTrue(DateSystem.IsPublicHoliday(new DateTime(year, month, expectedBoxingDay), CountryCode.IM));
+        }
+
+        [TestMethod]
+        [DataRow(2015, 1, 1)]
+        [DataRow(2016, 1, 1)]
+        [DataRow(2017, 1, 2)]
+        [DataRow(2018, 1, 1)]
+        [DataRow(2019, 1, 1)]
+        [DataRow(2020, 1, 1)]
+        [DataRow(2021, 1, 1)]
+        [DataRow(2022, 1, 3)]
+        public void CheckNewYearsDay(int year, int month, int expectedNewYearsDay)
+        {
+            Assert.IsTrue(DateSystem.IsPublicHoliday(new DateTime(year, month, expectedNewYearsDay), CountryCode.IM));
+        }
+    }
+}

--- a/src/Nager.Date/PublicHolidays/IsleOfManProvider.cs
+++ b/src/Nager.Date/PublicHolidays/IsleOfManProvider.cs
@@ -74,7 +74,7 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(christmasDay, "Christmas Day", "Christmas Day", countryCode));
 
             var stStephensDay = new DateTime(year, 12, 26).Shift(saturday => saturday.AddDays(2), sunday => sunday.AddDays(2));
-            items.Add(new PublicHoliday(sanktStehpenDay, "Boxing Day", "St. Stephen's Day", countryCode));
+            items.Add(new PublicHoliday(stStephensDay, "Boxing Day", "St. Stephen's Day", countryCode));
 
             return items.OrderBy(o => o.Date);
         }

--- a/src/Nager.Date/PublicHolidays/IsleOfManProvider.cs
+++ b/src/Nager.Date/PublicHolidays/IsleOfManProvider.cs
@@ -1,4 +1,5 @@
 using Nager.Date.Contract;
+using Nager.Date.Extensions;
 using Nager.Date.Model;
 using System;
 using System.Collections.Generic;
@@ -27,24 +28,110 @@ namespace Nager.Date.PublicHolidays
         {
             var countryCode = CountryCode.IM;
 
-            var firstMondayInMay = DateSystem.FindDay(year, Month.May, DayOfWeek.Monday, Occurrence.First);
-            var lastMondayInMay = DateSystem.FindLastDay(year, Month.May, DayOfWeek.Monday);
-            var secondFridayInJune = DateSystem.FindDay(year, Month.June, DayOfWeek.Friday, Occurrence.Second);
-            var lastMondayInAugust = DateSystem.FindLastDay(year, Month.August, DayOfWeek.Monday);
-
             var items = new List<PublicHoliday>();
-            items.Add(new PublicHoliday(year, 1, 1, "New Year's Day", "New Year's Day", countryCode));
+
+            #region New Year's Day with fallback
+
+            var newYearDay = new DateTime(year, 1, 1).Shift(saturday => saturday.AddDays(2), sunday => sunday.AddDays(1));
+            items.Add(new PublicHoliday(newYearDay, "New Year's Day", "New Year's Day", countryCode));
+
+            #endregion
+
+            var earlyMayBankHoliday = this.GetEarlyMayBankHoliday(year, countryCode);
+            if (earlyMayBankHoliday != null)
+            {
+                items.Add(earlyMayBankHoliday);
+            }
+
             items.Add(this._catholicProvider.GoodFriday("Good Friday", year, countryCode));
             items.Add(this._catholicProvider.EasterMonday("Easter Monday", year, countryCode));
-            items.Add(new PublicHoliday(firstMondayInMay, "Labour Day", "Labour Day", countryCode));
-            items.Add(new PublicHoliday(lastMondayInMay, "Spring Bank Holiday", "Spring Bank Holiday", countryCode));
-            items.Add(new PublicHoliday(secondFridayInJune, "Senior Race Day", "Senior Race Day", countryCode));
-            items.Add(new PublicHoliday(year, 7, 5, "Tynwald Day", "Tynwald Day", countryCode));
+
+            var springBankHoliday = this.GetSpringBankHoliday(year, countryCode);
+            if (springBankHoliday != null)
+            {
+                items.Add(springBankHoliday);
+            }
+
+            var queensPlatinumJubilee = this.GetQueensPlatinumJubilee(year, countryCode);
+            if (queensPlatinumJubilee != null)
+            {
+                items.Add(queensPlatinumJubilee);
+            }
+
+            var ttRaceDay = this.GetTTRaceDay(year, countryCode);
+            if (ttRaceDay != null)
+            {
+                items.Add(ttRaceDay);
+            }
+
+            var tynwaldDay = new DateTime(year, 7, 5).Shift(saturday => saturday.AddDays(2), sunday => sunday.AddDays(1));
+            items.Add(new PublicHoliday(tynwaldDay, "Tynwald Day", "Tynwald Day", countryCode));
+
+            var lastMondayInAugust = DateSystem.FindLastDay(year, Month.August, DayOfWeek.Monday);
             items.Add(new PublicHoliday(lastMondayInAugust, "Late Summer Bank Holiday", "Late Summer Bank Holiday", countryCode));
-            items.Add(new PublicHoliday(year, 12, 25, "Christmas Day", "Christmas Day", countryCode));
-            items.Add(new PublicHoliday(year, 12, 26, "Boxing Day", "St. Stephen's Day", countryCode));
+
+            var christmasDay = new DateTime(year, 12, 25).Shift(saturday => saturday.AddDays(2), sunday => sunday.AddDays(2));
+            items.Add(new PublicHoliday(christmasDay, "Christmas Day", "Christmas Day", countryCode));
+
+            var stStephensDay = new DateTime(year, 12, 26).Shift(saturday => saturday.AddDays(2), sunday => sunday.AddDays(2));
+            items.Add(new PublicHoliday(sanktStehpenDay, "Boxing Day", "St. Stephen's Day", countryCode));
 
             return items.OrderBy(o => o.Date);
+        }
+
+        private PublicHoliday GetTTRaceDay(int year, CountryCode countryCode)
+        {
+            var holidayName = "Senior Race Day";
+
+            if (year == 2020)
+            {
+                var replacementTTDay = new DateTime(2020, 8, 28);
+                return new PublicHoliday(replacementTTDay, holidayName, holidayName, countryCode, 1978);
+            }
+
+            //The friday after the first saturday of June
+            var ttRaceDay = DateSystem.FindDay(DateSystem.FindDay(year, Month.June, DayOfWeek.Saturday, Occurrence.First), DayOfWeek.Friday);
+            return new PublicHoliday(ttRaceDay, holidayName, holidayName, countryCode, 1978);
+        }
+
+        private PublicHoliday GetEarlyMayBankHoliday(int year, CountryCode countryCode)
+        {
+            var holidayName = "Early May Bank Holiday";
+
+            if (year == 2020)
+            {
+                //https://www.gov.uk/government/news/extra-bank-holiday-to-mark-the-queens-platinum-jubilee-in-2022
+                var secondFridayInMay = DateSystem.FindDay(year, Month.May, DayOfWeek.Friday, Occurrence.Second);
+                return new PublicHoliday(secondFridayInMay, holidayName, holidayName, countryCode, 1978);
+            }
+
+            var firstMondayInMay = DateSystem.FindDay(year, Month.May, DayOfWeek.Monday, Occurrence.First);
+            return new PublicHoliday(firstMondayInMay, holidayName, holidayName, countryCode, 1978);
+        }
+
+        private PublicHoliday GetSpringBankHoliday(int year, CountryCode countryCode)
+        {
+            var name = "Spring Bank Holiday";
+
+            if (year == 2022)
+            {
+                //https://www.gov.uk/government/news/extra-bank-holiday-to-mark-the-queens-platinum-jubilee-in-2022
+                return new PublicHoliday(year, 6, 2, name, name, countryCode);
+            }
+
+            var lastMondayInMay = DateSystem.FindLastDay(year, Month.May, DayOfWeek.Monday);
+            return new PublicHoliday(lastMondayInMay, name, name, countryCode);
+        }
+
+        private PublicHoliday GetQueensPlatinumJubilee(int year, CountryCode countryCode)
+        {
+            if (year == 2022)
+            {
+                //https://www.bbc.co.uk/news/uk-59929077
+                return new PublicHoliday(year, 6, 3, "Queen’s Platinum Jubilee", "Queen’s Platinum Jubilee", countryCode);
+            }
+
+            return null;
         }
 
         ///<inheritdoc/>
@@ -53,6 +140,7 @@ namespace Nager.Date.PublicHolidays
             return new string[]
             {
                 "https://en.wikipedia.org/wiki/Public_holidays_in_the_Isle_of_Man",
+                "https://www.gov.im/categories/home-and-neighbourhood/bank-holidays/"
             };
         }
     }


### PR DESCRIPTION
The current bank holidays are fairly basic and don't line up with the actual observed holidays.

Amended bank holidays to shift at weekends and added adjustments for VE Day & Queen Jubilee.
Most of the holidays follow similar rules to UK so are mostly copied from the UK provider.
Renamed 'Labour Day' to 'Early May Bank Holiday' in line with the gov.im page
https://www.gov.im/categories/home-and-neighbourhood/bank-holidays/

Also added in tests for most bank holidays since 2015 based on data from [Wayback Machine](https://web.archive.org/web/20150316155431/http://www.gov.im/categories/home-and-neighbourhood/bank-holidays/)