### PR TITLE
New Zealand: New public holiday Matariki 2022 onwards

### DIFF
--- a/src/Nager.Date.UnitTest/Country/NewZealandTest.cs
+++ b/src/Nager.Date.UnitTest/Country/NewZealandTest.cs
@@ -1,0 +1,53 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace Nager.Date.UnitTest.Country;
+
+[TestClass]
+public class NewZealandTest
+{
+    [TestMethod]
+    [DataRow(2022, 6, 24, true)]
+    [DataRow(2023, 7, 14, true)]
+    [DataRow(2024, 6, 28, true)]
+    [DataRow(2025, 6, 20, true)]
+    [DataRow(2026, 7, 10, true)]
+    [DataRow(2027, 6, 25, true)]
+    [DataRow(2028, 7, 14, true)]
+    [DataRow(2029, 7, 6, true)]
+    [DataRow(2030, 6, 21, true)]
+    [DataRow(2031, 7, 11, true)]
+    [DataRow(2032, 7, 2, true)]
+    [DataRow(2033, 6, 24, true)]
+    [DataRow(2034, 7, 7, true)]
+    [DataRow(2035, 6, 29, true)]
+    [DataRow(2036, 7, 18, true)]
+    [DataRow(2037, 7, 10, true)]
+    [DataRow(2038, 6, 25, true)]
+    [DataRow(2039, 7, 15, true)]
+    [DataRow(2040, 7, 6, true)]
+    [DataRow(2041, 7, 19, true)]
+    [DataRow(2042, 7, 11, true)]
+    [DataRow(2043, 7, 3, true)]
+    [DataRow(2044, 6, 24, true)]
+    [DataRow(2045, 7, 7, true)]
+    [DataRow(2046, 6, 29, true)]
+    [DataRow(2047, 7, 19, true)]
+    [DataRow(2048, 7, 3, true)]
+    [DataRow(2049, 6, 25, true)]
+    [DataRow(2050, 7, 15, true)]
+    [DataRow(2051, 6, 30, true)]
+    [DataRow(2052, 6, 21, true)]
+    public void ChecksIsMatarikiPublicHoliday(int year, int month, int day, bool expected)
+    {
+        // Arrange
+        var date = new DateTime(year, month, day);
+
+        // Act
+        var result = DateSystem.IsPublicHoliday(date, CountryCode.NZ);
+
+        // Assert
+        Assert.AreEqual(expected, result);
+        Assert.AreEqual(DayOfWeek.Friday, date.DayOfWeek);
+    }
+}

--- a/src/Nager.Date/PublicHolidays/NewZealandProvider.cs
+++ b/src/Nager.Date/PublicHolidays/NewZealandProvider.cs
@@ -3,6 +3,7 @@ using Nager.Date.Extensions;
 using Nager.Date.Model;
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 
 namespace Nager.Date.PublicHolidays
@@ -13,6 +14,27 @@ namespace Nager.Date.PublicHolidays
     public class NewZealandProvider : IPublicHolidayProvider
     {
         private readonly ICatholicProvider _catholicProvider;
+
+        /// <summary>
+        /// Matariki (Maori New Year) is introduced as a national public holiday beginning in 2022.
+        /// The first 30 years of dates have been agreed upon by the Matariki Advisory Committee.
+        /// The dates have been chosen to account for adjustments between the Maori lunar calendar and
+        /// the Gregorian calendar, while ensuring the public holiday falls on a Friday.
+        /// </summary>
+        private static readonly IDictionary<int, DateTime> _matariki = new List<DateTime>
+        {
+            new DateTime(2022, 6, 24), new DateTime(2023, 7, 14), new DateTime(2024, 6, 28),
+            new DateTime(2025, 6, 20), new DateTime(2026, 7, 10), new DateTime(2027, 6, 25),
+            new DateTime(2028, 7, 14), new DateTime(2029, 7, 6), new DateTime(2030, 6, 21),
+            new DateTime(2031, 7, 11), new DateTime(2032, 7, 2), new DateTime(2033, 6, 24),
+            new DateTime(2034, 7, 7), new DateTime(2035, 6, 29), new DateTime(2036, 7, 18),
+            new DateTime(2037, 7, 10), new DateTime(2038, 6, 25), new DateTime(2039, 7, 15),
+            new DateTime(2040, 7, 6), new DateTime(2041, 7, 19), new DateTime(2042, 7, 11),
+            new DateTime(2043, 7, 3), new DateTime(2044, 6, 24), new DateTime(2045, 7, 7),
+            new DateTime(2046, 6, 29), new DateTime(2047, 7, 19), new DateTime(2048, 7, 3),
+            new DateTime(2049, 6, 25), new DateTime(2050, 7, 15), new DateTime(2051, 6, 30),
+            new DateTime(2052, 6, 21),
+        }.ToDictionary(x => x.Year);
 
         /// <summary>
         /// NewZealandProvider
@@ -84,7 +106,7 @@ namespace Nager.Date.PublicHolidays
             var boxingDay = new DateTime(year, 12, 26).Shift(saturday => saturday.AddDays(2), sunday => sunday.AddDays(2));
             items.Add(new PublicHoliday(boxingDay, "Boxing Day", "Boxing Day", countryCode));
 
-        #endregion
+            #endregion
 
             #region Regional Anniversary Days
             // https://www.employment.govt.nz/leave-and-holidays/public-holidays/public-holidays-and-anniversary-dates/
@@ -135,6 +157,15 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(queensBirthday, "Queen's Birthday", "Queen's Birthday", countryCode));
             items.Add(new PublicHoliday(labourDay, "Labour Day", "Labour Day", countryCode));
 
+            #region Matariki
+
+            if (_matariki.TryGetValue(year, out var matariki))
+            {
+                items.Add(new PublicHoliday(matariki, "Matariki", "Matariki", countryCode));
+            }
+
+            #endregion
+
             return items.OrderBy(o => o.Date);
         }
 
@@ -143,7 +174,8 @@ namespace Nager.Date.PublicHolidays
         {
             return new string[]
             {
-                "https://en.wikipedia.org/wiki/Public_holidays_in_New_Zealand"
+                "https://en.wikipedia.org/wiki/Public_holidays_in_New_Zealand",
+                "https://www.mbie.govt.nz/assets/matariki-dates-2022-to-2052-matariki-advisory-group.pdf"
             };
         }
     }


### PR DESCRIPTION
Adding support for a new national public holiday for New Zealand in 2022 onwards, Matariki (Maori New Year).

This is a list of dates agreed upon by committee, determined for each year to take into account adjustments between the Maori lunar calendar and the Gregorian calendar, and ensuring the holiday falls on a Friday each year.

30 years of dates have been pre-determined, and this list may need to be changed if it gets adjusted.