### PR TITLE
Add Queen's state funeral as a public holiday

### DIFF
--- a/src/Nager.Date.UnitTest/Country/UnitedKingdomTest.cs
+++ b/src/Nager.Date.UnitTest/Country/UnitedKingdomTest.cs
@@ -55,7 +55,7 @@ namespace Nager.Date.UnitTest.Country
 
             Assert.AreEqual(expected, result);
         }
-        
+
         [DataTestMethod]
         [DataRow(2015, 12, 25, 28)]
         [DataRow(2016, 12, 27, 26)]
@@ -68,6 +68,15 @@ namespace Nager.Date.UnitTest.Country
         {
             Assert.IsTrue(DateSystem.IsPublicHoliday(new DateTime(year, month, expectedChristmasDay), CountryCode.GB));
             Assert.IsTrue(DateSystem.IsPublicHoliday(new DateTime(year, month, expectedBoxingDay), CountryCode.GB));
+        }
+
+        [DataTestMethod]
+        [DataRow(2021, 9, 19, false)]
+        [DataRow(2022, 9, 19, true)]
+        [DataRow(2023, 9, 19, false)]
+        public void CheckQueensStateFuneral(int year, int month, int day, bool isBankHoliday)
+        {
+            Assert.AreEqual(DateSystem.IsPublicHoliday(new DateTime(year, month, day), CountryCode.GB), isBankHoliday);
         }
     }
 }

--- a/src/Nager.Date/PublicHolidays/UnitedKingdomProvider.cs
+++ b/src/Nager.Date/PublicHolidays/UnitedKingdomProvider.cs
@@ -85,6 +85,12 @@ namespace Nager.Date.PublicHolidays
                 items.Add(queensPlatinumJubilee);
             }
 
+            var queensStateFuneral = this.GetQueensStateFuneral(year, countryCode);
+            if (queensStateFuneral != null)
+            {
+                items.Add(queensStateFuneral);
+            }
+
             #region Christmas Day with fallback
 
             var christmasDay = new DateTime(year, 12, 25).Shift(saturday => saturday.AddDays(2), sunday => sunday.AddDays(2));
@@ -121,6 +127,16 @@ namespace Nager.Date.PublicHolidays
             if (year == 2022)
             {
                 return new PublicHoliday(year, 6, 3, "Queen’s Platinum Jubilee", "Queen’s Platinum Jubilee", countryCode);
+            }
+
+            return null;
+        }
+
+        private PublicHoliday GetQueensStateFuneral(int year, CountryCode countryCode)
+        {
+            if (year == 2022)
+            {
+                return new PublicHoliday(year, 9, 19, "Queen’s State Funeral", "Queen’s State Funeral", countryCode);
             }
 
             return null;

--- a/src/Nager.Date/PublicHolidays/UnitedKingdomProvider.cs
+++ b/src/Nager.Date/PublicHolidays/UnitedKingdomProvider.cs
@@ -122,10 +122,13 @@ namespace Nager.Date.PublicHolidays
             return new PublicHoliday(lastMondayInMay, name, name, countryCode, 1971);
         }
 
+        #region Royal family
+
         private PublicHoliday GetQueensPlatinumJubilee(int year, CountryCode countryCode)
         {
             if (year == 2022)
             {
+                //Majesty Queen Elizabeth II’s
                 return new PublicHoliday(year, 6, 3, "Queen’s Platinum Jubilee", "Queen’s Platinum Jubilee", countryCode);
             }
 
@@ -136,11 +139,14 @@ namespace Nager.Date.PublicHolidays
         {
             if (year == 2022)
             {
+                //Majesty Queen Elizabeth II’s (https://www.gov.uk/government/news/bank-holiday-announced-for-her-majesty-queen-elizabeth-iis-state-funeral-on-monday-19-september)
                 return new PublicHoliday(year, 9, 19, "Queen’s State Funeral", "Queen’s State Funeral", countryCode);
             }
 
             return null;
         }
+
+        #endregion
 
         private PublicHoliday GetEarlyMayBankHoliday(int year, CountryCode countryCode)
         {


### PR DESCRIPTION
Affected country
United Kingdom

Affected public holiday
Queens State Funeral

Source of the information
[https://www.gov.uk/government/news/bank-holiday-announced-for-her-majesty-queen-elizabeth-iis-state-funeral-on-monday-19-september](https://www.gov.uk/government/news/bank-holiday-announced-for-her-majesty-queen-elizabeth-iis-state-funeral-on-monday-19-september)

More Information
Added Queen's state funeral following pattern for adding Queen's Platinum Jubilee