### PR TITLE
United Kingdom

### DIFF
--- a/src/Nager.Date.UnitTest/Country/UnitedKingdomTest.cs
+++ b/src/Nager.Date.UnitTest/Country/UnitedKingdomTest.cs
@@ -71,5 +71,15 @@ namespace Nager.Date.UnitTest.Country
         {
             Assert.AreEqual(DateSystem.IsPublicHoliday(new DateTime(year, month, day), CountryCode.GB), isBankHoliday);
         }
+
+        [DataTestMethod]
+        [DataRow(2021, 5, 8, false)]
+        [DataRow(2022, 5, 8, false)]
+        [DataRow(2023, 5, 8, true)]
+        [DataRow(2024, 5, 8, false)]
+        public void CheckKingCharlesCoronation(int year, int month, int day, bool isBankHoliday)
+        {
+            Assert.AreEqual(DateSystem.IsPublicHoliday(new DateTime(year, month, day), CountryCode.GB), isBankHoliday);
+        }
     }
 }

--- a/src/Nager.Date/PublicHolidays/UnitedKingdomProvider.cs
+++ b/src/Nager.Date/PublicHolidays/UnitedKingdomProvider.cs
@@ -103,6 +103,12 @@ namespace Nager.Date.PublicHolidays
                 items.Add(queensStateFuneral);
             }
 
+            var coronationBankHoliday = this.CoronationBankHoliday(year, countryCode);
+            if (coronationBankHoliday != null)
+            {
+                    items.Add(coronationBankHoliday);
+                }
+
             #region Christmas Day with fallback
 
             var christmasDay = new DateTime(year, 12, 25).Shift(saturday => saturday.AddDays(2), sunday => sunday.AddDays(2));
@@ -153,6 +159,17 @@ namespace Nager.Date.PublicHolidays
             {
                 //Majesty Queen Elizabeth II’s (https://www.gov.uk/government/news/bank-holiday-announced-for-her-majesty-queen-elizabeth-iis-state-funeral-on-monday-19-september)
                 return new PublicHoliday(year, 9, 19, "Queen’s State Funeral", "Queen’s State Funeral", countryCode);
+            }
+
+            return null;
+        }
+
+        private PublicHoliday CoronationBankHoliday(int year, CountryCode countryCode)
+        {
+            if (year == 2023)
+            {
+                //Bank holiday proclaimed in honour of the coronation of His Majesty King Charles III (https://www.gov.uk/government/news/bank-holiday-proclaimed-in-honour-of-the-coronation-of-his-majesty-king-charles-iii)
+                return new PublicHoliday(year, 5, 8, "Coronation Bank Holiday", "Coronation Bank Holiday", countryCode);
             }
 
             return null;

--- a/src/Nager.Date/PublicHolidays/UnitedKingdomProvider.cs
+++ b/src/Nager.Date/PublicHolidays/UnitedKingdomProvider.cs
@@ -106,8 +106,8 @@ namespace Nager.Date.PublicHolidays
             var coronationBankHoliday = this.CoronationBankHoliday(year, countryCode);
             if (coronationBankHoliday != null)
             {
-                    items.Add(coronationBankHoliday);
-                }
+                items.Add(coronationBankHoliday);
+            }
 
             #region Christmas Day with fallback
 
@@ -168,7 +168,9 @@ namespace Nager.Date.PublicHolidays
         {
             if (year == 2023)
             {
-                //Bank holiday proclaimed in honour of the coronation of His Majesty King Charles III (https://www.gov.uk/government/news/bank-holiday-proclaimed-in-honour-of-the-coronation-of-his-majesty-king-charles-iii)
+                //Bank holiday proclaimed in honour of the coronation of His Majesty King Charles III
+                //https://www.gov.uk/government/news/bank-holiday-proclaimed-in-honour-of-the-coronation-of-his-majesty-king-charles-iii
+
                 return new PublicHoliday(year, 5, 8, "Coronation Bank Holiday", "Coronation Bank Holiday", countryCode);
             }
 


### PR DESCRIPTION
UK just announced new bank holiday for the coronation of King Charles III

https://www.gov.uk/government/news/bank-holiday-proclaimed-in-honour-of-the-coronation-of-his-majesty-king-charles-iii
https://www.bbc.co.uk/news/uk-63528830