### PR TITLE
Isle of Man - Missing Royal Holidays

### DIFF
--- a/src/Nager.Date.UnitTest/Country/IsleOfManTest.cs
+++ b/src/Nager.Date.UnitTest/Country/IsleOfManTest.cs
@@ -135,5 +135,25 @@ namespace Nager.Date.UnitTest.Country
         {
             Assert.IsTrue(DateSystem.IsPublicHoliday(new DateTime(year, month, expectedNewYearsDay), CountryCode.IM));
         }
+
+
+        [DataTestMethod]
+        [DataRow(2021, 9, 19, false)]
+        [DataRow(2022, 9, 19, true)]
+        [DataRow(2023, 9, 19, false)]
+        public void CheckQueensStateFuneral(int year, int month, int day, bool isBankHoliday)
+        {
+            Assert.AreEqual(DateSystem.IsPublicHoliday(new DateTime(year, month, day), CountryCode.IM), isBankHoliday);
+        }
+
+        [DataTestMethod]
+        [DataRow(2021, 5, 8, false)]
+        [DataRow(2022, 5, 8, false)]
+        [DataRow(2023, 5, 8, true)]
+        [DataRow(2024, 5, 8, false)]
+        public void CheckKingCharlesCoronation(int year, int month, int day, bool isBankHoliday)
+        {
+            Assert.AreEqual(DateSystem.IsPublicHoliday(new DateTime(year, month, day), CountryCode.IM), isBankHoliday);
+        }
     }
 }

--- a/src/Nager.Date/PublicHolidays/IsleOfManProvider.cs
+++ b/src/Nager.Date/PublicHolidays/IsleOfManProvider.cs
@@ -52,10 +52,22 @@ namespace Nager.Date.PublicHolidays
                 items.Add(springBankHoliday);
             }
 
-            var queensPlatinumJubilee = this.GetQueensPlatinumJubilee(year, countryCode);
+            var queensPlatinumJubilee = this.QueensPlatinumJubilee(year, countryCode);
             if (queensPlatinumJubilee != null)
             {
                 items.Add(queensPlatinumJubilee);
+            }
+
+            var queensStateFuneral = this.QueensStateFuneral(year, countryCode);
+            if (queensStateFuneral != null)
+            {
+                items.Add(queensStateFuneral);
+            }
+
+            var coronationBankHoliday = this.CoronationBankHoliday(year, countryCode);
+            if (coronationBankHoliday != null)
+            {
+                items.Add(coronationBankHoliday);
             }
 
             var ttRaceDay = this.GetTTRaceDay(year, countryCode);
@@ -123,16 +135,46 @@ namespace Nager.Date.PublicHolidays
             return new PublicHoliday(lastMondayInMay, name, name, countryCode);
         }
 
-        private PublicHoliday GetQueensPlatinumJubilee(int year, CountryCode countryCode)
+
+        #region Royal family
+
+        private PublicHoliday QueensPlatinumJubilee(int year, CountryCode countryCode)
         {
             if (year == 2022)
             {
-                //https://www.bbc.co.uk/news/uk-59929077
+                //Majesty Queen Elizabeth II’s
                 return new PublicHoliday(year, 6, 3, "Queen’s Platinum Jubilee", "Queen’s Platinum Jubilee", countryCode);
             }
 
             return null;
         }
+
+        private PublicHoliday QueensStateFuneral(int year, CountryCode countryCode)
+        {
+            if (year == 2022)
+            {
+                //Majesty Queen Elizabeth II’s (https://www.gov.uk/government/news/bank-holiday-announced-for-her-majesty-queen-elizabeth-iis-state-funeral-on-monday-19-september)
+                return new PublicHoliday(year, 9, 19, "Queen’s State Funeral", "Queen’s State Funeral", countryCode);
+            }
+
+            return null;
+        }
+
+        private PublicHoliday CoronationBankHoliday(int year, CountryCode countryCode)
+        {
+            if (year == 2023)
+            {
+                //Bank holiday proclaimed in honour of the coronation of His Majesty King Charles III
+                //https://www.gov.uk/government/news/bank-holiday-proclaimed-in-honour-of-the-coronation-of-his-majesty-king-charles-iii
+
+                return new PublicHoliday(year, 5, 8, "Coronation Bank Holiday", "Coronation Bank Holiday", countryCode);
+            }
+
+            return null;
+        }
+
+        #endregion
+
 
         ///<inheritdoc/>
         public IEnumerable<string> GetSources()

--- a/src/Nager.Date/PublicHolidays/IsleOfManProvider.cs
+++ b/src/Nager.Date/PublicHolidays/IsleOfManProvider.cs
@@ -166,6 +166,7 @@ namespace Nager.Date.PublicHolidays
             {
                 //Bank holiday proclaimed in honour of the coronation of His Majesty King Charles III
                 //https://www.gov.uk/government/news/bank-holiday-proclaimed-in-honour-of-the-coronation-of-his-majesty-king-charles-iii
+                //https://www.iomtoday.co.im/news/extra-bank-holiday-to-mark-king-charles-iiis-coronation-571967
 
                 return new PublicHoliday(year, 5, 8, "Coronation Bank Holiday", "Coronation Bank Holiday", countryCode);
             }


### PR DESCRIPTION
https://www.gov.im/categories/home-and-neighbourhood/bank-holidays/
https://www.iomtoday.co.im/news/extra-bank-holiday-to-mark-king-charles-iiis-coronation-571967

The past holiday 19/09/2022 was missing and the upcoming 08/05/2023 was added to be observed by Isle of Man as well.
