### PR TITLE
fix: incorrect counties for Australia and Bosnia And Herzegovina 

### DIFF
--- a/src/Nager.Date.UnitTest/Common/LogicTest.cs
+++ b/src/Nager.Date.UnitTest/Common/LogicTest.cs
@@ -217,17 +217,17 @@ namespace Nager.Date.UnitTest.Common
         {
             var isPublicHoliday = DateSystem.IsPublicHoliday(new DateTime(2019, 8, 5), CountryCode.AU);
             Assert.IsFalse(isPublicHoliday);
-            isPublicHoliday = DateSystem.IsPublicHoliday(new DateTime(2019, 8, 5), CountryCode.AU, "AUS-NT");
+            isPublicHoliday = DateSystem.IsPublicHoliday(new DateTime(2019, 8, 5), CountryCode.AU, "AU-NT");
             Assert.IsTrue(isPublicHoliday);
-            isPublicHoliday = DateSystem.IsPublicHoliday(new DateTime(2019, 8, 5), CountryCode.AU, "AUS-WA");
+            isPublicHoliday = DateSystem.IsPublicHoliday(new DateTime(2019, 8, 5), CountryCode.AU, "AU-WA");
             Assert.IsFalse(isPublicHoliday);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException), "Invalid countyCode AU-NT")]
+        [ExpectedException(typeof(ArgumentException), "Invalid countyCode AUS-NT")]
         public void CheckIsOfficialPublicHolidayByCounty2()
         {
-            var isPublicHoliday = DateSystem.IsPublicHoliday(new DateTime(2019, 8, 5), CountryCode.AU, "AU-NT");
+            var isPublicHoliday = DateSystem.IsPublicHoliday(new DateTime(2019, 8, 5), CountryCode.AU, "AUS-NT");
             Assert.IsTrue(isPublicHoliday);
         }
 

--- a/src/Nager.Date/PublicHolidays/AustraliaProvider.cs
+++ b/src/Nager.Date/PublicHolidays/AustraliaProvider.cs
@@ -28,14 +28,14 @@ namespace Nager.Date.PublicHolidays
         {
             return new Dictionary<string, string>
             {
-                { "AUS-ACT", "Australian Capital Territory" },
-                { "AUS-NSW", "New South Wales" },
-                { "AUS-NT", "Northern Territory" },
-                { "AUS-QLD", "Queensland" },
-                { "AUS-SA", "South Australia" },
-                { "AUS-TAS", "Tasmania" },
-                { "AUS-VIC", "Victoria" },
-                { "AUS-WA", "Western Australia" }
+                { "AU-ACT", "Australian Capital Territory" },
+                { "AU-NSW", "New South Wales" },
+                { "AU-NT", "Northern Territory" },
+                { "AU-QLD", "Queensland" },
+                { "AU-SA", "South Australia" },
+                { "AU-TAS", "Tasmania" },
+                { "AU-VIC", "Victoria" },
+                { "AU-WA", "Western Australia" }
             };
         }
 
@@ -60,23 +60,23 @@ namespace Nager.Date.PublicHolidays
             var items = new List<PublicHoliday>();
             items.Add(new PublicHoliday(year, 1, 1, "New Year's Day", "New Year's Day", countryCode));
             items.Add(new PublicHoliday(australiaDay, "Australia Day", "Australia Day", countryCode));
-            items.Add(new PublicHoliday(firstMondayInMarch, "Labour Day", "Labour Day", countryCode, null, new string[] { "AUS-WA" }));
-            items.Add(new PublicHoliday(secondMondayInMarch, "Canberra Day", "Canberra Day", countryCode, null, new string[] { "AUS-ACT" }));
-            items.Add(new PublicHoliday(secondMondayInMarch, "March Public Holiday", "March Public Holiday", countryCode, null, new string[] { "AUS-SA" }));
-            items.Add(new PublicHoliday(secondMondayInMarch, "Eight Hours Day", "Eight Hours Day", countryCode, null, new string[] { "AUS-TAS" }));
-            items.Add(new PublicHoliday(secondMondayInMarch, "Labour Day", "Labour Day", countryCode, null, new string[] { "AUS-VIC" }));
+            items.Add(new PublicHoliday(firstMondayInMarch, "Labour Day", "Labour Day", countryCode, null, new string[] { "AU-WA" }));
+            items.Add(new PublicHoliday(secondMondayInMarch, "Canberra Day", "Canberra Day", countryCode, null, new string[] { "AU-ACT" }));
+            items.Add(new PublicHoliday(secondMondayInMarch, "March Public Holiday", "March Public Holiday", countryCode, null, new string[] { "AU-SA" }));
+            items.Add(new PublicHoliday(secondMondayInMarch, "Eight Hours Day", "Eight Hours Day", countryCode, null, new string[] { "AU-TAS" }));
+            items.Add(new PublicHoliday(secondMondayInMarch, "Labour Day", "Labour Day", countryCode, null, new string[] { "AU-VIC" }));
             items.Add(this._catholicProvider.GoodFriday("Good Friday", year, countryCode));
-            items.Add(new PublicHoliday(easterSunday.AddDays(-1), "Easter Eve", "Holy Saturday", countryCode, null, new string[] { "AUS-ACT", "AUS-NSW", "AUS-NT", "AUS-QLD", "AUS-SA", "AUS-VIC" }));
-            items.Add(this._catholicProvider.EasterSunday("Easter Sunday", year, countryCode).SetCounties("AUS-ACT", "AUS-NSW", "AUS-VIC"));
+            items.Add(new PublicHoliday(easterSunday.AddDays(-1), "Easter Eve", "Holy Saturday", countryCode, null, new string[] { "AU-ACT", "AU-NSW", "AU-NT", "AU-QLD", "AU-SA", "AU-VIC" }));
+            items.Add(this._catholicProvider.EasterSunday("Easter Sunday", year, countryCode).SetCounties("AU-ACT", "AU-NSW", "AU-VIC"));
             items.Add(this._catholicProvider.EasterMonday("Easter Monday", year, countryCode));
             items.Add(new PublicHoliday(year, 4, 25, "Anzac Day", "Anzac Day", countryCode));
-            items.Add(new PublicHoliday(firstMondayInMay, "May Day", "May Day", countryCode, null, new string[] { "AUS-NT" }));
-            items.Add(new PublicHoliday(firstMondayInMay, "Labour Day", "Labour Day", countryCode, null, new string[] { "AUS-QLD" }));
-            items.Add(new PublicHoliday(firstMondayAfterOr27May, "Reconciliation Day", "Reconciliation Day", countryCode, 2018, new string[] { "AUS-ACT" }));
-            items.Add(new PublicHoliday(firstMondayInJune, "Western Australia Day", "Western Australia Day", countryCode, null, new string[] { "AUS-WA" }));
-            items.Add(new PublicHoliday(secondMondayInJune, "Queen's Birthday", "Queen's Birthday", countryCode, null, new string[] { "AUS-ACT", "AUS-NSW", "AUS-NT", "AUS-SA", "AUS-TAS", "AUS-VIC" }));
-            items.Add(new PublicHoliday(firstMondayInAugust, "Picnic Day", "Picnic Day", countryCode, null, new string[] { "AUS-NT" }));
-            items.Add(new PublicHoliday(firstMondayInOctober, "Labour Day", "Labour Day", countryCode, null, new string[] { "AUS-ACT", "AUS-NSW", "AUS-SA" }));
+            items.Add(new PublicHoliday(firstMondayInMay, "May Day", "May Day", countryCode, null, new string[] { "AU-NT" }));
+            items.Add(new PublicHoliday(firstMondayInMay, "Labour Day", "Labour Day", countryCode, null, new string[] { "AU-QLD" }));
+            items.Add(new PublicHoliday(firstMondayAfterOr27May, "Reconciliation Day", "Reconciliation Day", countryCode, 2018, new string[] { "AU-ACT" }));
+            items.Add(new PublicHoliday(firstMondayInJune, "Western Australia Day", "Western Australia Day", countryCode, null, new string[] { "AU-WA" }));
+            items.Add(new PublicHoliday(secondMondayInJune, "Queen's Birthday", "Queen's Birthday", countryCode, null, new string[] { "AU-ACT", "AU-NSW", "AU-NT", "AU-SA", "AU-TAS", "AU-VIC" }));
+            items.Add(new PublicHoliday(firstMondayInAugust, "Picnic Day", "Picnic Day", countryCode, null, new string[] { "AU-NT" }));
+            items.Add(new PublicHoliday(firstMondayInOctober, "Labour Day", "Labour Day", countryCode, null, new string[] { "AU-ACT", "AU-NSW", "AU-SA" }));
             items.Add(new PublicHoliday(year, 12, 25, "Christmas Day", "Christmas Day", countryCode));
             items.Add(new PublicHoliday(boxingDay, "Boxing Day", "St. Stephen's Day", countryCode));
 

--- a/src/Nager.Date/PublicHolidays/BosniaAndHerzegovinaProvider.cs
+++ b/src/Nager.Date/PublicHolidays/BosniaAndHerzegovinaProvider.cs
@@ -26,8 +26,8 @@ namespace Nager.Date.PublicHolidays
         {
             return new Dictionary<string, string>
             {
-                { "BA-FBIH", "Federation of Bosnia and Herzegovina" },
-                { "BA-RS", "Republic of Serbia" }
+                { "BA-BIH", "Federation of Bosnia and Herzegovina" },
+                { "BA-SRP", "Republic of Serbia" }
             };
         }
 
@@ -39,20 +39,20 @@ namespace Nager.Date.PublicHolidays
             var items = new List<PublicHoliday>();
             items.Add(new PublicHoliday(year, 1, 1, "Nova Godina", "New Year's Day", countryCode));
             items.Add(new PublicHoliday(year, 1, 2, "Nova Godina", "New Year's Day", countryCode));
-            items.Add(new PublicHoliday(year, 1, 6, "Božić (za pravoslavce)", "Christmas Eve (Orthodox)", countryCode, null, new string[] { "BA-RS" }));
-            items.Add(new PublicHoliday(year, 1, 7, "Božić (za pravoslavce)", "Christmas Day (Orthodox)", countryCode, null, new string[] { "BA-RS" }));
-            items.Add(new PublicHoliday(year, 3, 1, "Dan nezavisnosti Bosne i Hercegovine", "Idependence day", countryCode, null, new string[] { "BA-FBIH" }));
+            items.Add(new PublicHoliday(year, 1, 6, "Božić (za pravoslavce)", "Christmas Eve (Orthodox)", countryCode, null, new string[] { "BA-SRP" }));
+            items.Add(new PublicHoliday(year, 1, 7, "Božić (za pravoslavce)", "Christmas Day (Orthodox)", countryCode, null, new string[] { "BA-SRP" }));
+            items.Add(new PublicHoliday(year, 3, 1, "Dan nezavisnosti Bosne i Hercegovine", "Idependence day", countryCode, null, new string[] { "BA-BIH" }));
             items.Add(new PublicHoliday(year, 5, 1, "Praznik rada", "May Day / International Workers' Day", countryCode));
             items.Add(new PublicHoliday(year, 5, 2, "Praznik rada", "May Day / International Workers' Day", countryCode));
-            items.Add(new PublicHoliday(year, 5, 9, "Dan pobjede nad fašizmom", "Victory Day over fascism", countryCode, null, new string[] { "BA-RS" }));
-            items.Add(new PublicHoliday(year, 11, 21, "Dan uspostavljanja Opšteg okvirnog sporazuma za mir u BiH", "Day of the establishment of the General Framework Agreement for Peace in BiH ", countryCode, null, new string[] { "BA-RS" }));
-            items.Add(new PublicHoliday(year, 11, 25, "Dan državnosti Bosne i Hercegovine", "Statehood Day", countryCode, null, new string[] { "BA-FBIH" }));
-            items.Add(new PublicHoliday(year, 12, 24, "Božić (za rimokatolike)", "Christmas Eve (Roman Catholic)", countryCode, null, new string[] { "BA-FBIH" }));
-            items.Add(new PublicHoliday(year, 12, 25, "Božić (za rimokatolike)", "Christmas Day (Roman Catholic)", countryCode, null, new string[] { "BA-FBIH" }));
+            items.Add(new PublicHoliday(year, 5, 9, "Dan pobjede nad fašizmom", "Victory Day over fascism", countryCode, null, new string[] { "BA-SRP" }));
+            items.Add(new PublicHoliday(year, 11, 21, "Dan uspostavljanja Opšteg okvirnog sporazuma za mir u BiH", "Day of the establishment of the General Framework Agreement for Peace in BiH ", countryCode, null, new string[] { "BA-SRP" }));
+            items.Add(new PublicHoliday(year, 11, 25, "Dan državnosti Bosne i Hercegovine", "Statehood Day", countryCode, null, new string[] { "BA-BIH" }));
+            items.Add(new PublicHoliday(year, 12, 24, "Božić (za rimokatolike)", "Christmas Eve (Roman Catholic)", countryCode, null, new string[] { "BA-BIH" }));
+            items.Add(new PublicHoliday(year, 12, 25, "Božić (za rimokatolike)", "Christmas Day (Roman Catholic)", countryCode, null, new string[] { "BA-BIH" }));
 
-            items.Add(this._orthodoxProvider.GoodFriday("Veliki petak", year, countryCode).SetCounties("BA-RS"));
-            items.Add(this._orthodoxProvider.EasterSunday("Vaskrs (Uskrs)", year, countryCode).SetCounties("BA-RS"));
-            items.Add(this._orthodoxProvider.EasterMonday("Vaskrsni (Uskrsni) ponedeljak", year, countryCode).SetCounties("BA-RS"));
+            items.Add(this._orthodoxProvider.GoodFriday("Veliki petak", year, countryCode).SetCounties("BA-SRP"));
+            items.Add(this._orthodoxProvider.EasterSunday("Vaskrs (Uskrs)", year, countryCode).SetCounties("BA-SRP"));
+            items.Add(this._orthodoxProvider.EasterMonday("Vaskrsni (Uskrsni) ponedeljak", year, countryCode).SetCounties("BA-SRP"));
             
 
             return items.OrderBy(o => o.Date);


### PR DESCRIPTION
Hey, 

I was looking through holidays and I've noticed that ISO 3166-2 codes for two of the countries Australia and 
Bosnia And Herzegovina are incorrect inside of Public Holidays. 

I've corrected them using codes specified in wikipedia for [Australia](https://en.wikipedia.org/wiki/ISO_3166-2:AU) and [Bosnia and Herzegovina](https://en.wikipedia.org/wiki/ISO_3166-2:BA). 

I was also considering adding [Brčko distrikt (BA-BRC)](https://en.wikipedia.org/wiki/Br%C4%8Dko_District) to the list of counties, but decided against it as [BAH wikipedia holiday page](https://en.wikipedia.org/wiki/Public_holidays_in_Bosnia_and_Herzegovina) does not state anything about holidays in that district. 

Let me know what you think.

Thanks! 