### PR TITLE
Canada - Fix British Columbia Day

### DIFF
--- a/src/Nager.Date/PublicHolidays/CanadaProvider.cs
+++ b/src/Nager.Date/PublicHolidays/CanadaProvider.cs
@@ -71,7 +71,8 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(year, 6, 24, "Discovery Day", "Discovery Day", countryCode, null, new string[] { "CA-NL" }));
             items.Add(new PublicHoliday(year, 6, 24, "Fête nationale du Québec", "National Holiday", countryCode, null, new string[] { "CA-QC" }));
             items.Add(new PublicHoliday(year, 7, 12, "Orangemen's Day", "Orangemen's Day", countryCode, null, new string[] { "CA-NL" }));
-            items.Add(new PublicHoliday(firstMondayInAugust, "Civic Holiday", "Civic Holiday", countryCode, null, new string[] { "CA-BC", "CA-MB", "CA-NL", "CA-NT", "CA-NU", "CA-ON" }));
+            items.Add(new PublicHoliday(firstMondayInAugust, "Civic Holiday", "Civic Holiday", countryCode, null, new string[] {"CA-MB", "CA-NL", "CA-NT", "CA-NU", "CA-ON" }));
+            items.Add(new PublicHoliday(firstMondayInAugust, "British Columbia Day", "British Columbia Day", countryCode, null, new string[] { "CA-BC" }));
             items.Add(new PublicHoliday(firstMondayInAugust, "Heritage Day", "Heritage Day", countryCode, null, new string[] { "CA-AB", "CA-YT" }));
             items.Add(new PublicHoliday(firstMondayInAugust, "New Brunswick Day", "New Brunswick Day", countryCode, null, new string[] { "CA-NB" }));
             items.Add(new PublicHoliday(firstMondayInAugust, "Natal Day", "Natal Day", countryCode, null, new string[] { "CA-NS" }));


### PR DESCRIPTION
BC Day was mistakenly named as civic holiday. 

Issue #539