### PR TITLE
Singapore - Fix Deepavali Day

### DIFF
--- a/src/Nager.Date/PublicHolidays/SingaporeProvider.cs
+++ b/src/Nager.Date/PublicHolidays/SingaporeProvider.cs
@@ -172,7 +172,7 @@ namespace Nager.Date.PublicHolidays
                 case 2023:
                     return new PublicHoliday(year, 11, 13, name, name, countryCode).Shift(saturday => saturday, sunday => sunday.AddDays(1));
                 case 2024:
-                    return new PublicHoliday(year, 11, 1, name, name, countryCode).Shift(saturday => saturday, sunday => sunday.AddDays(1));
+                    return new PublicHoliday(year, 10, 31, name, name, countryCode).Shift(saturday => saturday, sunday => sunday.AddDays(1));
                 case 2025:
                     return new PublicHoliday(year, 10, 21, name, name, countryCode).Shift(saturday => saturday, sunday => sunday.AddDays(1));
                 case 2026:

--- a/src/Nager.Date/PublicHolidays/SingaporeProvider.cs
+++ b/src/Nager.Date/PublicHolidays/SingaporeProvider.cs
@@ -170,7 +170,7 @@ namespace Nager.Date.PublicHolidays
                 case 2022:
                     return new PublicHoliday(year, 10, 24, name, name, countryCode).Shift(saturday => saturday, sunday => sunday.AddDays(1));
                 case 2023:
-                    return new PublicHoliday(year, 11, 13, name, name, countryCode).Shift(saturday => saturday, sunday => sunday.AddDays(1));
+                    return new PublicHoliday(year, 11, 12, name, name, countryCode).Shift(saturday => saturday, sunday => sunday.AddDays(1));
                 case 2024:
                     return new PublicHoliday(year, 10, 31, name, name, countryCode).Shift(saturday => saturday, sunday => sunday.AddDays(1));
                 case 2025:


### PR DESCRIPTION
The Deepavali day is mismatched: 
 - Expected day: Oct 31 2024
 - Actual day: Nov 1 2024

Source: https://www.mom.gov.sg/newsroom/press-releases/2023/0524-public-holidays-for-2024