### PR TITLE
Rename Scotland 2 january holiday

### DIFF
--- a/src/Nager.Date/HolidayProviders/UnitedKingdomHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/UnitedKingdomHolidayProvider.cs
@@ -94,8 +94,8 @@ namespace Nager.Date.HolidayProviders
                 new HolidaySpecification
                 {
                     Date = new DateTime(year, 1, 2),
-                    EnglishName = "New Year's Day",
-                    LocalName = "New Year's Day",
+                    EnglishName = "2 January",
+                    LocalName = "2 January",
                     HolidayTypes = HolidayTypes.Public,
                     SubdivisionCodes = ["GB-SCT"],
                     ObservedRuleSet = monday1ObservedRuleSet


### PR DESCRIPTION
The second holiday of the year in Scotland is not called "New Year's Day", the closest it has to a name is plain "2 January".

https://www.mygov.scot/scotland-bank-holidays