### PR TITLE
Support Morocco Amazigh new year starting from 2024

### DIFF
--- a/src/Nager.Date.UnitTest/Countries/MoroccoTest.cs
+++ b/src/Nager.Date.UnitTest/Countries/MoroccoTest.cs
@@ -1,0 +1,33 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace Nager.Date.UnitTest.Countries
+{
+    [TestClass]
+    public class MoroccoTest
+    {
+        [TestMethod]
+        public void TestAmazighNewYearAfter2024()
+        {
+            var newAmazighYear = new DateTime(2026, 1, 14);
+            var isPublicHoliday = HolidaySystem.IsPublicHoliday(newAmazighYear, CountryCode.MA);
+            Assert.IsTrue(isPublicHoliday);
+        }
+
+        [TestMethod]
+        public void TestAmazighNewYearAt2024()
+        {
+            var newAmazighYear = new DateTime(2024, 1, 14);
+            var isPublicHoliday = HolidaySystem.IsPublicHoliday(newAmazighYear, CountryCode.MA);
+            Assert.IsTrue(isPublicHoliday);
+        }
+
+        [TestMethod]
+        public void TestAmazighNewYearBefore2024()
+        {
+            var newAmazighYear = new DateTime(2023, 1, 14);
+            var isPublicHoliday = HolidaySystem.IsPublicHoliday(newAmazighYear, CountryCode.MA);
+            Assert.IsFalse(isPublicHoliday);
+        }
+    }
+}

--- a/src/Nager.Date/HolidayProviders/MoroccoHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/MoroccoHolidayProvider.cs
@@ -95,6 +95,17 @@ namespace Nager.Date.HolidayProviders
                 }
             };
 
+            if (year >= 2024)
+            {
+                holidaySpecifications.Add(new HolidaySpecification
+                {
+                    Date = new DateTime(year, 1, 14),
+                    EnglishName = "Amazigh New Year",
+                    LocalName = "Id Yennayer",
+                    HolidayTypes = HolidayTypes.Public
+                });
+            }
+
             var holidays = HolidaySpecificationProcessor.Process(holidaySpecifications, countryCode);
             return holidays.OrderBy(o => o.Date);
 


### PR DESCRIPTION
Morocco has stated January the 14th as an official paid public holiday, starting from 2024.
Read more here https://www.moroccoworldnews.com/2023/08/356893/moroccan-government-sets-amazigh-new-years-official-date-on-january-14 