### PR TITLE
Update to Ukrainian holidays in UkraineHolidayProvider.cs

### DIFF
--- a/src/Nager.Date/HolidayProviders/UkraineHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/UkraineHolidayProvider.cs
@@ -51,13 +51,6 @@ namespace Nager.Date.HolidayProviders
                 },
                 new HolidaySpecification
                 {
-                    Date = new DateTime(year, 5, year < 2024 ? 9 : 8),
-                    EnglishName = "Victory day over Nazism in World War II",
-                    LocalName = "День перемоги над нацизмом у Другій світовій війні",
-                    HolidayTypes = HolidayTypes.Public
-                },
-                new HolidaySpecification
-                {
                     Date = new DateTime(year, 6, 28),
                     EnglishName = "Constitution Day",
                     LocalName = "День Конституції",
@@ -78,9 +71,34 @@ namespace Nager.Date.HolidayProviders
             holidaySpecifications.AddIfNotNull(this.StatehoodDay(year));
             holidaySpecifications.AddIfNotNull(this.DefenderDay(year));
             holidaySpecifications.AddIfNotNull(this.GregorianChristmasDay(year));
+            holidaySpecifications.AddIfNotNull(this.VictoryDay(year));
 
             return holidaySpecifications;
-            
+        }
+
+        private HolidaySpecification VictoryDay(int year)
+        {
+            var englishName = "Victory day over Nazism in World War II";
+            var localName = "День перемоги над нацизмом у Другій світовій війні";
+
+            if (year < 2024)
+            {
+                return new HolidaySpecification
+                {
+                    Date = new DateTime(year, 5, 9),
+                    EnglishName = englishName,
+                    LocalName = localName,
+                    HolidayTypes = HolidayTypes.Public
+                };
+            }
+
+            return new HolidaySpecification
+            {
+                Date = new DateTime(year, 5, 8),
+                EnglishName = englishName,
+                LocalName = localName,
+                HolidayTypes = HolidayTypes.Public
+            };
         }
 
         private HolidaySpecification? JulianChristmasDay(int year)
@@ -161,7 +179,7 @@ namespace Nager.Date.HolidayProviders
         {
             if (year >= 2017)
             {
-                return new new HolidaySpecification
+                return new HolidaySpecification
                 {
                     Date = new DateTime(year, 12, 25),
                     EnglishName = "(Gregorian and Revised Julian) Christmas",

--- a/src/Nager.Date/HolidayProviders/UkraineHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/UkraineHolidayProvider.cs
@@ -37,13 +37,6 @@ namespace Nager.Date.HolidayProviders
                 },
                 new HolidaySpecification
                 {
-                    Date = new DateTime(year, 1, 7),
-                    EnglishName = "(Julian) Christmas",
-                    LocalName = "Різдво",
-                    HolidayTypes = HolidayTypes.Public
-                },
-                new HolidaySpecification
-                {
                     Date = new DateTime(year, 3, 8),
                     EnglishName = "International Women's Day",
                     LocalName = "Міжнародний жіночий день",
@@ -58,7 +51,7 @@ namespace Nager.Date.HolidayProviders
                 },
                 new HolidaySpecification
                 {
-                    Date = new DateTime(year, 5, 9),
+                    Date = new DateTime(year, 5, year < 2024 ? 9 : 8),
                     EnglishName = "Victory day over Nazism in World War II",
                     LocalName = "День перемоги над нацизмом у Другій світовій війні",
                     HolidayTypes = HolidayTypes.Public
@@ -79,13 +72,6 @@ namespace Nager.Date.HolidayProviders
                 },
                 new HolidaySpecification
                 {
-                    Date = new DateTime(year, 10, 14),
-                    EnglishName = "Defender of Ukraine Day",
-                    LocalName = "День захисника України",
-                    HolidayTypes = HolidayTypes.Public
-                },
-                new HolidaySpecification
-                {
                     Date = new DateTime(year, 12, 25),
                     EnglishName = "(Gregorian and Revised Julian) Christmas",
                     LocalName = "Різдво",
@@ -95,15 +81,34 @@ namespace Nager.Date.HolidayProviders
                 this._orthodoxProvider.Pentecost("Трійця", year)
             };
 
+            holidaySpecifications.AddIfNotNull(this.JulianChristmasDay(year));
             holidaySpecifications.AddIfNotNull(this.StatehoodDay(year));
+            holidaySpecifications.AddIfNotNull(this.DefenderDay(year));
 
             return holidaySpecifications;
+            
+        }
+
+        private HolidaySpecification? JulianChristmasDay(int year)
+        {
+            if (year < 2024)
+            {
+                return new HolidaySpecification
+                {
+                    Date = new DateTime(year, 1, 7),
+                    EnglishName = "(Julian) Christmas",
+                    LocalName = "Різдво",
+                    HolidayTypes = HolidayTypes.Public
+                };
+            }
+            
+            return null;
         }
 
         private HolidaySpecification? StatehoodDay(int year)
         {
             var englishName = "Statehood Day";
-            var localName = "Statehood Day";
+            var localName = "День Української Державності";
 
             if (year == 2022 || year == 2023)
             {
@@ -126,6 +131,35 @@ namespace Nager.Date.HolidayProviders
                 };
             }
 
+            return null;
+        }
+
+        private HolidaySpecification? DefenderDay(int year)
+        {
+            var englishName = "Defender of Ukraine Day";
+            var localName = "День захисників і захисниць України";
+
+            if (year >= 2015 && year < 2023)
+            {
+                return new HolidaySpecification
+                {
+                    Date = new DateTime(year, 10, 14),
+                    EnglishName = englishName,
+                    LocalName = localName,
+                    HolidayTypes = HolidayTypes.Public
+                };
+            }
+            else if (year >= 2023)
+            {
+                return new HolidaySpecification
+                {
+                    Date = new DateTime(year, 10, 1),
+                    EnglishName = englishName,
+                    LocalName = localName,
+                    HolidayTypes = HolidayTypes.Public
+                };
+            }
+            
             return null;
         }
 

--- a/src/Nager.Date/HolidayProviders/UkraineHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/UkraineHolidayProvider.cs
@@ -70,13 +70,6 @@ namespace Nager.Date.HolidayProviders
                     LocalName = "День Незалежності",
                     HolidayTypes = HolidayTypes.Public
                 },
-                new HolidaySpecification
-                {
-                    Date = new DateTime(year, 12, 25),
-                    EnglishName = "(Gregorian and Revised Julian) Christmas",
-                    LocalName = "Різдво",
-                    HolidayTypes = HolidayTypes.Public
-                },
                 this._orthodoxProvider.EasterSunday("Великдень", year),
                 this._orthodoxProvider.Pentecost("Трійця", year)
             };
@@ -84,6 +77,7 @@ namespace Nager.Date.HolidayProviders
             holidaySpecifications.AddIfNotNull(this.JulianChristmasDay(year));
             holidaySpecifications.AddIfNotNull(this.StatehoodDay(year));
             holidaySpecifications.AddIfNotNull(this.DefenderDay(year));
+            holidaySpecifications.AddIfNotNull(this.GregorianChristmasDay(year));
 
             return holidaySpecifications;
             
@@ -156,6 +150,22 @@ namespace Nager.Date.HolidayProviders
                     Date = new DateTime(year, 10, 1),
                     EnglishName = englishName,
                     LocalName = localName,
+                    HolidayTypes = HolidayTypes.Public
+                };
+            }
+            
+            return null;
+        }
+
+        private HolidaySpecification? GregorianChristmasDay(int year)
+        {
+            if (year >= 2017)
+            {
+                return new new HolidaySpecification
+                {
+                    Date = new DateTime(year, 12, 25),
+                    EnglishName = "(Gregorian and Revised Julian) Christmas",
+                    LocalName = "Різдво",
                     HolidayTypes = HolidayTypes.Public
                 };
             }


### PR DESCRIPTION
Changes to Ukraine Holidays
Victory Day over Nazism in World War II changed to 03.08 starting from 2024 Deleted Julian Christmas starting from 2024
Changed Defender of Ukraine Day dates to be accurate from 2015 to 2023 and from 2023 onward. All new dates are inline with original source https://en.wikipedia.org/wiki/Public_holidays_in_Ukraine