### PR TITLE
Fix local names for some Puerto Rico, Dominican Republic, and El Salvador holidays

### DIFF
--- a/src/Nager.Date/HolidayProviders/DominicanRepublicHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/DominicanRepublicHolidayProvider.cs
@@ -31,56 +31,56 @@ namespace Nager.Date.HolidayProviders
                 {
                     Date = new DateTime(year, 1, 1),
                     EnglishName = "New Year's Day",
-                    LocalName = "New Year's Day",
+                    LocalName = "Día de Año Nuevo",
                     HolidayTypes = HolidayTypes.Public
                 },
                 new HolidaySpecification
                 {
                     Date = new DateTime(year, 1, 6),
                     EnglishName = "Day of Kings",
-                    LocalName = "Dia de Reyes",
+                    LocalName = "Día de Reyes",
                     HolidayTypes = HolidayTypes.Public
                 },
                 new HolidaySpecification
                 {
                     Date = new DateTime(year, 1, 21),
                     EnglishName = "Our Lady of Altagracia",
-                    LocalName = "Our Lady of Altagracia",
+                    LocalName = "Día de Nuestra Señora de la Altagracia",
                     HolidayTypes = HolidayTypes.Public
                 },
                 new HolidaySpecification
                 {
                     Date = new DateTime(year, 1, 26),
                     EnglishName = "Duarte's Birthday",
-                    LocalName = "Duarte's Birthday",
+                    LocalName = "Día del Natalicio de Juan Pablo Duarte",
                     HolidayTypes = HolidayTypes.Public
                 },
                 new HolidaySpecification
                 {
                     Date = new DateTime(year, 2, 27),
                     EnglishName = "Independence Day",
-                    LocalName = "Independence Day",
+                    LocalName = "Día de la Independencia de la República Dominicana",
                     HolidayTypes = HolidayTypes.Public
                 },
                 new HolidaySpecification
                 {
                     Date = new DateTime(year, 5, 1),
                     EnglishName = "Labour Day",
-                    LocalName = "Labour Day",
+                    LocalName = "Día del Trabajador",
                     HolidayTypes = HolidayTypes.Public
                 },
                 new HolidaySpecification
                 {
                     Date = new DateTime(year, 5, 28),
                     EnglishName = "Mother's Day",
-                    LocalName = "Mother's Day",
+                    LocalName = "Día de las Madres",
                     HolidayTypes = HolidayTypes.Public
                 },
                 new HolidaySpecification
                 {
                     Date = new DateTime(year, 8, 16),
                     EnglishName = "Restoration Day",
-                    LocalName = "Restoration Day",
+                    LocalName = "Día de la Restauración Dominicana",
                     HolidayTypes = HolidayTypes.Public
                 },
                 new HolidaySpecification
@@ -94,14 +94,14 @@ namespace Nager.Date.HolidayProviders
                 {
                     Date = new DateTime(year, 11, 6),
                     EnglishName = "Constitution Day",
-                    LocalName = "Constitution Day",
+                    LocalName = "Día de la Constitución",
                     HolidayTypes = HolidayTypes.Public
                 },
                 new HolidaySpecification
                 {
                     Date = new DateTime(year, 12, 25),
                     EnglishName = "Christmas Day",
-                    LocalName = "Christmas Day",
+                    LocalName = "Navidad",
                     HolidayTypes = HolidayTypes.Public
                 },
                 this._catholicProvider.GoodFriday("Good Friday", year),

--- a/src/Nager.Date/HolidayProviders/ElSalvadorHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/ElSalvadorHolidayProvider.cs
@@ -33,7 +33,7 @@ namespace Nager.Date.HolidayProviders
                 {
                     Date = new DateTime(year, 5, 1),
                     EnglishName = "Labor Day",
-                    LocalName = "Día del trabajo",
+                    LocalName = "Día del Trabajo",
                     HolidayTypes = HolidayTypes.Public
                 },
                 new HolidaySpecification

--- a/src/Nager.Date/HolidayProviders/PuertoRicoHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/PuertoRicoHolidayProvider.cs
@@ -148,14 +148,14 @@ namespace Nager.Date.HolidayProviders
                 {
                     Date = secondMondayInOctober,
                     EnglishName = "Columbus Day",
-                    LocalName = "Día de la Raza Descubrimiento de América",
+                    LocalName = "Día de la Raza / Descubrimiento de América",
                     HolidayTypes = HolidayTypes.Public
                 },
                 new HolidaySpecification
                 {
                     Date = new DateTime(year, 11, 11),
                     EnglishName = "Veterans Day",
-                    LocalName = "Día del Veterano Día del Armisticio",
+                    LocalName = "Día del Veterano / Día del Armisticio",
                     HolidayTypes = HolidayTypes.Public,
                     ObservedRuleSet = observedRuleSet
                 },


### PR DESCRIPTION
Changes:
- Puerto Rico - Some holiday names have alternative titles that were not separated by `/`. Added this as it seemed like proper convention.
- Dominican Republic - Added local names for holidays that were still in English. These were sourced to the best of my abilities from reading articles to the names that they use but I'm open for corrections.
- El Salvador - Uppercased letter as it seemed like convention. Other "Día del Trabajo" exist in the codebase with the new capitalization.

As for the Puerto Rico local names, some of these holidays that have alternative names I've never heard anyone use as a Puerto Rican myself that's lived all my life here. I don't know if you would be open for changes to these.