### PR TITLE
Holiday - Germany - Berlin - LiberationDay 2025

### DIFF
--- a/src/Nager.Date/HolidayProviders/GermanyHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/GermanyHolidayProvider.cs
@@ -282,7 +282,7 @@ namespace Nager.Date.HolidayProviders
 
         private HolidaySpecification? LiberationDay(int year)
         {
-            if (year == 2020)
+            if (year == 2020 || year == 2025)
             {
                 return new HolidaySpecification
                 {


### PR DESCRIPTION
LiberationDay is an holiday in berlin in 2025 once:

Source: https://www.berlin.de/aktuelles/9188766-958090-einmaliger-feiertag-am-8-mai-2025.html#:~:text=%C2%ABOrt%20der%20Kapitulation%C2%BB%20steht%20auf,in%20Berlin%20zum%20gesetzlichen%20Feiertag. 