### PR TITLE
chore: Extend Dependabot Support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,18 @@ updates:
       - "enhancement"
     # Allow up to 5 open pull requests for nuget dependencies
     open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "tinohager
+      - "samtrion"
+    commit-message:
+      prefix: chore
+    labels:
+      - "dependencies"
+      - "enhancement"
+    # Allow up to 5 open pull requests for nuget dependencies
+    open-pull-requests-limit: 5

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     paths:
     - 'src/**'
+    - '.github/workflows/**'
     branches: [ main ]
 
 jobs:
@@ -32,3 +33,19 @@ jobs:
       working-directory: ./src
       run: |
         dotnet test --configuration Release --no-restore --no-build --verbosity normal
+
+  dependabot:
+    name: Dependabot Auto Merge
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    if: ${{ github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' }}
+
+    steps:
+      - name: Dependabot Auto Merge
+        uses: dailydevops/dependamerge-action@v1.2.19
+        with:
+          token: ${{ secrets.DEPENDABOT }}
+          command: squash
+          handle-submodule: true
+          target: minor

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Dependabot Auto Merge
         uses: dailydevops/dependamerge-action@v1.2.19
         with:
-          token: ${{ secrets.DEPENDABOT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           command: squash
           handle-submodule: true
           target: minor


### PR DESCRIPTION
The PR extends the functionality beyond the EcoSystem `nuget`, so that we will also receive dependency updates for `GitHub-Actions` in the future.

In addition, the PR build pipeline has been extended so that an additional step is now performed in the case of `dependabot[bot]` pull requests, which automates these PRs `merged` based on the configurations.

@tinohager For this to work properly, you would need to provide a `Dependabot Secret` with the name `DEPENDABOT`. A GITHUB_TOKEN should be used as the content, which receives the necessary authorizations for the authorization of the merge. For more information about [DependaMerge](https://github.com/dailydevops/dependamerge-action/) please read here.