### PR TITLE
United States - Add Truman Day and Lincoln's Birthday

### DIFF
--- a/src/Nager.Date/HolidayProviders/UnitedStatesHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/UnitedStatesHolidayProvider.cs
@@ -138,6 +138,14 @@ namespace Nager.Date.HolidayProviders
                 },
                 new HolidaySpecification
                 {
+                    Date = new DateTime(year, 5, 8),
+                    EnglishName = "Truman Day",
+                    LocalName = "Truman Day",
+                    HolidayTypes = HolidayTypes.Authorities | HolidayTypes.School,
+                    SubdivisionCodes = ["US-MO"]
+                },
+                new HolidaySpecification
+                {
                     Date = firstMondayInSeptember,
                     EnglishName = "Labor Day",
                     LocalName = "Labour Day",
@@ -180,22 +188,20 @@ namespace Nager.Date.HolidayProviders
 
             holidaySpecifications.AddIfNotNull(this.JuneteenthNationalIndependenceDay(year, observedRuleSet));
             holidaySpecifications.AddIfNotNull(this.IndigenousPeoplesDay(year));
+            holidaySpecifications.AddIfNotNull(this.LincolnsBirthday(year));
 
             return holidaySpecifications;
         }
 
-        private HolidaySpecification? LincolnsBirthday(
-            int year,
-            ObservedRuleSet observedRuleSet)
+        private HolidaySpecification? LincolnsBirthday(int year)
         {
             return new HolidaySpecification
             {
                 Date = new DateTime(year, 2, 12),
                 EnglishName = "Lincoln's Birthday",
                 LocalName = "Lincoln's Birthday",
-                HolidayTypes = HolidayTypes.Public,
-                SubdivisionCodes = ["US-MI", "US-IN", "US-IL", "US-MO"],
-                ObservedRuleSet = observedRuleSet
+                HolidayTypes = HolidayTypes.Observance,
+                SubdivisionCodes = ["US-CA", "US-CT", "US-IL", "US-IN", "US-KY", "US-MI", "US-NY", "US-MO", "US-OH"],
             };
         }
 

--- a/src/Nager.Date/HolidayProviders/UnitedStatesHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/UnitedStatesHolidayProvider.cs
@@ -184,6 +184,21 @@ namespace Nager.Date.HolidayProviders
             return holidaySpecifications;
         }
 
+        private HolidaySpecification? LincolnsBirthday(
+            int year,
+            ObservedRuleSet observedRuleSet)
+        {
+            return new HolidaySpecification
+            {
+                Date = new DateTime(year, 2, 12),
+                EnglishName = "Lincoln's Birthday",
+                LocalName = "Lincoln's Birthday",
+                HolidayTypes = HolidayTypes.Public,
+                SubdivisionCodes = ["US-MI", "US-IN", "US-IL", "US-MO"],
+                ObservedRuleSet = observedRuleSet
+            };
+        }
+
         private HolidaySpecification? JuneteenthNationalIndependenceDay(
             int year,
             ObservedRuleSet observedRuleSet)


### PR DESCRIPTION
The most important changes are the addition of Truman Day and Lincoln's Birthday to the holiday specifications.

New holiday specifications:

* Added Truman Day on May 8th to the list of holidays, which is observed in Missouri and categorized under authorities and school holidays.
* Added a new method `LincolnsBirthday` to define Lincoln's Birthday on February 12th, observed in multiple states and categorized as an observance holiday.