### PR TITLE
Slovenia - Add Primož Trubar Day and fix Sovereignty Day

### DIFF
--- a/src/Nager.Date/HolidayProviders/SloveniaHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/SloveniaHolidayProvider.cs
@@ -70,6 +70,13 @@ namespace Nager.Date.HolidayProviders
                     LocalName = "praznik dela",
                     HolidayTypes = HolidayTypes.Public
                 },
+                    new HolidaySpecification
+                {
+                    Date = new DateTime(year, 5, 2),
+                    EnglishName = "Primož Trubar day",
+                    LocalName = "dan Primoža Trubarja",
+                    HolidayTypes = HolidayTypes.Observance‎
+                },
                 new HolidaySpecification
                 {
                     Date = new DateTime(year, 6, 25),
@@ -105,11 +112,11 @@ namespace Nager.Date.HolidayProviders
                     LocalName = "dan slovenskega športa",
                     HolidayTypes = HolidayTypes.Observance
                 },
-                new HolidaySpecification
+                  new HolidaySpecification
                 {
-                    Date = new DateTime(year, 9, 25),
-                    EnglishName = "Sovereignty Day",
-                    LocalName = "dan slovenskega športa",
+                    Date = new DateTime(year, 10, 25),
+                    EnglishName = "sovereignty day",
+                    LocalName = "dan suverenosti",
                     HolidayTypes = HolidayTypes.Observance
                 },
                 new HolidaySpecification

--- a/src/Nager.Date/HolidayProviders/SloveniaHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/SloveniaHolidayProvider.cs
@@ -70,12 +70,12 @@ namespace Nager.Date.HolidayProviders
                     LocalName = "praznik dela",
                     HolidayTypes = HolidayTypes.Public
                 },
-                    new HolidaySpecification
+                new HolidaySpecification
                 {
                     Date = new DateTime(year, 5, 2),
                     EnglishName = "Primož Trubar day",
                     LocalName = "dan Primoža Trubarja",
-                    HolidayTypes = HolidayTypes.Observance‎
+                    HolidayTypes = HolidayTypes.Observance
                 },
                 new HolidaySpecification
                 {
@@ -110,13 +110,6 @@ namespace Nager.Date.HolidayProviders
                     Date = new DateTime(year, 9, 23),
                     EnglishName = "Slovenian Sports Day",
                     LocalName = "dan slovenskega športa",
-                    HolidayTypes = HolidayTypes.Observance
-                },
-                  new HolidaySpecification
-                {
-                    Date = new DateTime(year, 10, 25),
-                    EnglishName = "sovereignty day",
-                    LocalName = "dan suverenosti",
                     HolidayTypes = HolidayTypes.Observance
                 },
                 new HolidaySpecification
@@ -160,6 +153,7 @@ namespace Nager.Date.HolidayProviders
             };
 
             holidaySpecifications.AddIfNotNull(this.SolidarityDay(year));
+            holidaySpecifications.AddIfNotNull(this.SovereigntyDay(year));
 
             return holidaySpecifications;
         }
@@ -180,11 +174,28 @@ namespace Nager.Date.HolidayProviders
             return null;
         }
 
+        private HolidaySpecification? SovereigntyDay(int year)
+        {
+            if (year >= 2015)
+            {
+                return new HolidaySpecification
+                {
+                    Date = new DateTime(year, 8, 14),
+                    EnglishName = "Sovereignty Day",
+                    LocalName = "dan suverenosti",
+                    HolidayTypes = HolidayTypes.Observance
+                };
+            }
+
+            return null;
+        }
+
         /// <inheritdoc/>
         public override IEnumerable<string> GetSources()
         {
             return
             [
+                "https://www.gov.si/en/topics/national-holidays/",
                 "https://en.wikipedia.org/wiki/Public_holidays_in_Slovenia",
                 "https://www.gov.si/en/topics/national-holidays/",
                 "https://www.gov.si/teme/drzavni-prazniki-in-dela-prosti-dnevi/"

--- a/src/Nager.Date/HolidayProviders/SloveniaHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/SloveniaHolidayProvider.cs
@@ -73,7 +73,7 @@ namespace Nager.Date.HolidayProviders
                 new HolidaySpecification
                 {
                     Date = new DateTime(year, 5, 2),
-                    EnglishName = "Primož Trubar day",
+                    EnglishName = "Primož Trubar Day",
                     LocalName = "dan Primoža Trubarja",
                     HolidayTypes = HolidayTypes.Observance
                 },


### PR DESCRIPTION
Add day of Primož Trubar and fix 25th September to sovereignty day instead of sport day