### PR TITLE
Removed Pentecost Sunday as public holiday in Hesse

### DIFF
--- a/src/Nager.Date/HolidayProviders/GermanyHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/GermanyHolidayProvider.cs
@@ -115,7 +115,7 @@ namespace Nager.Date.HolidayProviders
                 this._catholicProvider.EasterSunday("Ostersonntag", year).SetSubdivisionCodes("DE-BB"),
                 this._catholicProvider.EasterMonday("Ostermontag", year),
                 this._catholicProvider.AscensionDay("Christi Himmelfahrt", year),
-                this._catholicProvider.Pentecost("Pfingstsonntag", year).SetSubdivisionCodes("DE-BB", "DE-HE"),
+                this._catholicProvider.Pentecost("Pfingstsonntag", year).SetSubdivisionCodes("DE-BB"),
                 this._catholicProvider.WhitMonday("Pfingstmontag", year),
                 this._catholicProvider.CorpusChristi("Fronleichnam", year).SetSubdivisionCodes("DE-BW", "DE-BY", "DE-HE", "DE-NW", "DE-RP", "DE-SL")
             };


### PR DESCRIPTION
This PR removes Pentecost Sunday (Pfingstsonntag) as a public holiday in the state of Hesse. It was incorrectly listed, despite never having been a holiday in Hesse. All occurrences of this holiday in Hesse have been removed to reflect the correct legal status. Pentecost Sunday is only recognized as a public holiday in Brandenburg.

Official list of public holidays in the federal state of Hesse: https://innen.hessen.de/buerger-staat/feiertage

Fix #791