### PR TITLE
Republic of Congo - Feat add all Holiday

### DIFF
--- a/src/Nager.Date/HolidayProviders/RepublicOfCongoHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/RepublicOfCongoHolidayProvider.cs
@@ -6,14 +6,14 @@ using System.Collections.Generic;
 namespace Nager.Date.HolidayProviders
 {
     /// <summary>
-    /// Republic Of Congo HolidayProvider
+    /// Republic of Congo HolidayProvider
     /// </summary>
     internal sealed class RepublicOfCongoHolidayProvider : AbstractHolidayProvider
     {
         private readonly ICatholicProvider _catholicProvider;
 
         /// <summary>
-        /// RepublicOfCongoProvider
+        /// Republic of Congo HolidayProvider
         /// </summary>
         /// <param name="catholicProvider"></param>
         public RepublicOfCongoHolidayProvider(
@@ -77,10 +77,10 @@ namespace Nager.Date.HolidayProviders
                     LocalName = "Noël",
                     HolidayTypes = HolidayTypes.Public,
                 },
-                this._catholicProvider.AscensionDay("Ascension Day", year),
-                this._catholicProvider.EasterSunday("Easter Sunday", year),
-                this._catholicProvider.EasterMonday("Easter Monday", year)
-                this._catholicProvider.WhitMonday("Whit Monday", year)
+                this._catholicProvider.AscensionDay("Ascension", year),
+                this._catholicProvider.EasterSunday("Dimanche de Pâques", year),
+                this._catholicProvider.EasterMonday("Lundi de Pâques", year),
+                this._catholicProvider.WhitMonday("Lundi de Pentecôte", year)
             };
 
             return holidaySpecifications;

--- a/src/Nager.Date/HolidayProviders/RepublicOfCongoHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/RepublicOfCongoHolidayProvider.cs
@@ -1,0 +1,98 @@
+using Nager.Date.Models;
+using Nager.Date.ReligiousProviders;
+using System;
+using System.Collections.Generic;
+
+namespace Nager.Date.HolidayProviders
+{
+    /// <summary>
+    /// Republic Of Congo HolidayProvider
+    /// </summary>
+    internal sealed class RepublicOfCongoHolidayProvider : AbstractHolidayProvider
+    {
+        private readonly ICatholicProvider _catholicProvider;
+
+        /// <summary>
+        /// RepublicOfCongoProvider
+        /// </summary>
+        /// <param name="catholicProvider"></param>
+        public RepublicOfCongoHolidayProvider(
+            ICatholicProvider catholicProvider) : base(CountryCode.CG)
+        {
+            this._catholicProvider = catholicProvider;
+        }
+
+        /// <inheritdoc/>
+        protected override IEnumerable<HolidaySpecification> GetHolidaySpecifications(int year)
+        {
+            //TODO: Add islamic public holidays
+
+            var holidaySpecifications = new List<HolidaySpecification>
+            {
+                new HolidaySpecification
+                {
+                    Date = new DateTime(year, 1, 1),
+                    EnglishName = "New Year's Day",
+                    LocalName = "Jour de l'An",
+                    HolidayTypes = HolidayTypes.Public,
+                },
+                new HolidaySpecification
+                {
+                    Date = new DateTime(year, 5, 1),
+                    EnglishName = "Labour Day",
+                    LocalName = "Fête du Travail",
+                    HolidayTypes = HolidayTypes.Public,
+                },
+                new HolidaySpecification
+                {
+                    Date = new DateTime(year, 6, 10),
+                    EnglishName = "Reconciliation Day",
+                    LocalName = "Fête de la Réconciliation",
+                    HolidayTypes = HolidayTypes.Public,
+                },
+                new HolidaySpecification
+                {
+                    Date = new DateTime(year, 8, 15),
+                    EnglishName = "National Day",
+                    LocalName = "Fête Nationale",
+                    HolidayTypes = HolidayTypes.Public,
+                },
+                new HolidaySpecification
+                {
+                    Date = new DateTime(year, 11, 1),
+                    EnglishName = "All Saints' Day",
+                    LocalName = "Toussaint",
+                    HolidayTypes = HolidayTypes.Public,
+                },
+                new HolidaySpecification
+                {
+                    Date = new DateTime(year, 11, 28),
+                    EnglishName = "Republic Day",
+                    LocalName = "Jour de la République",
+                    HolidayTypes = HolidayTypes.Public,
+                },
+                new HolidaySpecification
+                {
+                    Date = new DateTime(year, 12, 25),
+                    EnglishName = "Christmas Day",
+                    LocalName = "Noël",
+                    HolidayTypes = HolidayTypes.Public,
+                },
+                this._catholicProvider.AscensionDay("Ascension Day", year),
+                this._catholicProvider.EasterSunday("Easter Sunday", year),
+                this._catholicProvider.EasterMonday("Easter Monday", year)
+            };
+
+            return holidaySpecifications;
+        }
+
+        /// <inheritdoc/>
+        public override IEnumerable<string> GetSources()
+        {
+            return
+            [
+                "https://en.wikipedia.org/wiki/Public_holidays_in_the_Republic_of_the_Congo"
+            ];
+        }
+    }
+}

--- a/src/Nager.Date/HolidayProviders/RepublicOfCongoHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/RepublicOfCongoHolidayProvider.cs
@@ -25,7 +25,6 @@ namespace Nager.Date.HolidayProviders
         /// <inheritdoc/>
         protected override IEnumerable<HolidaySpecification> GetHolidaySpecifications(int year)
         {
-            //TODO: Add islamic public holidays
 
             var holidaySpecifications = new List<HolidaySpecification>
             {
@@ -81,6 +80,7 @@ namespace Nager.Date.HolidayProviders
                 this._catholicProvider.AscensionDay("Ascension Day", year),
                 this._catholicProvider.EasterSunday("Easter Sunday", year),
                 this._catholicProvider.EasterMonday("Easter Monday", year)
+                this._catholicProvider.WhitMonday("Whit Monday", year)
             };
 
             return holidaySpecifications;

--- a/src/Nager.Date/HolidaySystem.cs
+++ b/src/Nager.Date/HolidaySystem.cs
@@ -42,6 +42,7 @@ namespace Nager.Date
                 { CountryCode.BY, new Lazy<IHolidayProvider>(() => new BelarusHolidayProvider(_orthodoxProvider))},
                 { CountryCode.BZ, new Lazy<IHolidayProvider>(() => new BelizeHolidayProvider(_catholicProvider))},
                 { CountryCode.CA, new Lazy<IHolidayProvider>(() => new CanadaHolidayProvider(_catholicProvider))},
+                { CountryCode.CG, new Lazy<IHolidayProvider>(() => new RepublicOfCongoHolidayProvider(_catholicProvider))},
                 { CountryCode.CH, new Lazy<IHolidayProvider>(() => new SwitzerlandHolidayProvider(_catholicProvider))},
                 { CountryCode.CL, new Lazy<IHolidayProvider>(() => new ChileHolidayProvider(_catholicProvider))},
                 { CountryCode.CN, new Lazy<IHolidayProvider>(() => new ChinaHolidayProvider())},


### PR DESCRIPTION
### 🇨🇬 Republic of Congo – Add all public holidays  
**Feature**: Add holiday provider for the Republic of Congo  
**Related issue**: #795 

#### ✨ Changes  
- Added a new `RepublicOfCongoHolidayProvider` implementing all known public holidays.  
- Included official national holidays and common observances.  
- Ensured consistency with other holiday providers.  
