### PR TITLE
Luxembourg - Fix Europe Day

### DIFF
--- a/src/Nager.Date/HolidayProviders/LuxembourgHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/LuxembourgHolidayProvider.cs
@@ -90,7 +90,7 @@ namespace Nager.Date.HolidayProviders
 
         private HolidaySpecification? EuropeDay(int year)
         {
-            if (year >= EuropeDayIntroductionYear)
+            if (year >= 2019)
             {
                 return new HolidaySpecification
                 {


### PR DESCRIPTION
This pull request updates the `LuxembourgHolidayProvider` class to improve how the Europe Day holiday is handled and adds a new source of information for public holidays in Luxembourg. The key changes include refactoring the holiday specification logic and enhancing data sources.

### Holiday Specification Updates:

* Removed the hardcoded Europe Day holiday from the `GetHolidaySpecifications` method and replaced it with a dynamic check using a new private method, `EuropeDay(int year)`, which ensures Europe Day is only included for years 2019 and later.