### PR TITLE
Australia - Fix Adelaide Cup Day naming

### DIFF
--- a/src/Nager.Date/HolidayProviders/AustraliaHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/AustraliaHolidayProvider.cs
@@ -93,8 +93,8 @@ namespace Nager.Date.HolidayProviders
                 new HolidaySpecification
                 {
                     Date = secondMondayInMarch,
-                    EnglishName = "March Public Holiday",
-                    LocalName = "March Public Holiday",
+                    EnglishName = "Adelaide Cup Day",
+                    LocalName = "Adelaide Cup Day",
                     HolidayTypes = HolidayTypes.Public,
                     SubdivisionCodes = ["AU-SA"]
                 },


### PR DESCRIPTION
This pull request updates the holiday specifications in the `AustraliaHolidayProvider` class to reflect a more accurate naming for a specific public holiday in South Australia.

### Updates to holiday specifications:
* [`src/Nager.Date/HolidayProviders/AustraliaHolidayProvider.cs`](diffhunk://#diff-eb939e35f57a60e0b853d7429b45ea62a443d8d480e61c46f18a6bb329ccc39aL96-R97): Renamed the holiday on the second Monday in March from "March Public Holiday" to "Adelaide Cup Day" in both `EnglishName` and `LocalName` fields.

 
- https://github.com/nager/Nager.Date/issues/555