### PR TITLE
Italy - Add subdivision codes

### DIFF
--- a/src/Nager.Date/HolidayProviders/ItalyHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/ItalyHolidayProvider.cs
@@ -126,8 +126,7 @@ namespace Nager.Date.HolidayProviders
                     HolidayTypes = HolidayTypes.Public
                 },
                 this._catholicProvider.EasterSunday("Pasqua", year),
-                this._catholicProvider.EasterMonday("Lunedì dell'Angelo", year),
-                this._catholicProvider.WhitMonday("Pfingstmontag", year).SetSubdivisionCodes("IT-32"),
+                this._catholicProvider.EasterMonday("Lunedì dell'Angelo", year)
             };
 
             return holidaySpecifications;

--- a/src/Nager.Date/HolidayProviders/ItalyHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/ItalyHolidayProvider.cs
@@ -8,7 +8,7 @@ namespace Nager.Date.HolidayProviders
     /// <summary>
     /// Italy HolidayProvider
     /// </summary>
-    internal sealed class ItalyHolidayProvider : AbstractHolidayProvider
+    internal sealed class ItalyHolidayProvider : AbstractHolidayProvider, ISubdivisionCodesProvider
     {
         private readonly ICatholicProvider _catholicProvider;
 
@@ -20,6 +20,34 @@ namespace Nager.Date.HolidayProviders
             ICatholicProvider catholicProvider) : base(CountryCode.IT)
         {
             this._catholicProvider = catholicProvider;
+        }
+
+        /// <inheritdoc/>
+        public IDictionary<string, string> GetSubdivisionCodes()
+        {
+            return new Dictionary<string, string>
+            {
+                { "IT-65", "Abruzzo" },
+                { "IT-77", "Basilicata" },
+                { "IT-78", "Calabria" },
+                { "IT-72", "Campania" },
+                { "IT-45", "Emilia-Romagna" },
+                { "IT-36", "Friuli-Venezia Giulia" },
+                { "IT-62", "Lazio" },
+                { "IT-42", "Liguria" },
+                { "IT-25", "Lombardia" },
+                { "IT-57", "Marche" },
+                { "IT-67", "Molise" },
+                { "IT-21", "Piemonte" },
+                { "IT-75", "Puglia" },
+                { "IT-88", "Sardegna" },
+                { "IT-82", "Sicilia" },
+                { "IT-52", "Toscana" },
+                { "IT-32", "Trentino-Alto Adige/Südtirol" },
+                { "IT-55", "Umbria" },
+                { "IT-23", "Valle d’Aosta/Vallée d’Aoste" },
+                { "IT-34", "Veneto" }
+            };
         }
 
         /// <inheritdoc/>
@@ -98,7 +126,8 @@ namespace Nager.Date.HolidayProviders
                     HolidayTypes = HolidayTypes.Public
                 },
                 this._catholicProvider.EasterSunday("Pasqua", year),
-                this._catholicProvider.EasterMonday("Lunedì dell'Angelo", year)
+                this._catholicProvider.EasterMonday("Lunedì dell'Angelo", year),
+                this._catholicProvider.WhitMonday("Pfingstmontag", year).SetSubdivisionCodes("IT-32"),
             };
 
             return holidaySpecifications;


### PR DESCRIPTION
This pull request updates the `ItalyHolidayProvider` class in the `Nager.Date` library to implement subdivision codes functionality. The changes include adding the `ISubdivisionCodesProvider` interface and implementing a method to provide Italian subdivision codes.

### Addition of subdivision codes functionality:

* [`src/Nager.Date/HolidayProviders/ItalyHolidayProvider.cs`](diffhunk://#diff-e30f9443f23cee4424adb94dd00aaafffbc0375a6cfa68af26c8d9d74c72f104L11-R11): Updated the `ItalyHolidayProvider` class to implement the `ISubdivisionCodesProvider` interface, enabling the retrieval of Italian subdivision codes. Added the `GetSubdivisionCodes` method to return a dictionary mapping subdivision codes (e.g., "IT-65") to their corresponding names (e.g., "Abruzzo"). [[1]](diffhunk://#diff-e30f9443f23cee4424adb94dd00aaafffbc0375a6cfa68af26c8d9d74c72f104L11-R11) [[2]](diffhunk://#diff-e30f9443f23cee4424adb94dd00aaafffbc0375a6cfa68af26c8d9d74c72f104R25-R52)