### PR TITLE
Great prayer day is no longer a public holiday

### DIFF
--- a/src/Nager.Date/HolidayProviders/DenmarkHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/DenmarkHolidayProvider.cs
@@ -104,7 +104,7 @@ namespace Nager.Date.HolidayProviders
                     Date = easterSunday.AddDays(26),
                     EnglishName = "General Prayer Day",
                     LocalName = "Store bededag",
-                    HolidayTypes = HolidayTypes.Public
+                    HolidayTypes = HolidayTypes.Optional
                 };
             }
 


### PR DESCRIPTION
The holiday of Great Prayer day was removed in Denmark by law.

Link to law (in Danish): https://www.ft.dk/ripdf/samling/20222/lovforslag/l13/20222_l13_som_vedtaget.pdf

Many people still  observe it, especially in the private sector and among schools, but it is not a mandatory holiday anywhere (actually, it is the opposite for public institutions, where you HAVE to work, probably because it was quite unpopular, so the state needs to show that work can be done on that day). To facilitate this, I figured "Optional" was the best categorization.