### PR TITLE
Fix local name spelling of 'Labour Day' to 'Labor Day' for US holiday

### DIFF
--- a/src/Nager.Date/HolidayProviders/UnitedStatesHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/UnitedStatesHolidayProvider.cs
@@ -155,7 +155,7 @@ namespace Nager.Date.HolidayProviders
                     Id = "LABOURDAY-01",
                     Date = firstMondayInSeptember,
                     EnglishName = "Labour Day",
-                    LocalName = "Labour Day",
+                    LocalName = "Labor Day",
                     HolidayTypes = HolidayTypes.Public
                 },
                 new HolidaySpecification


### PR DESCRIPTION
Previously the English name was "Labor," but this was changed recently to reflect the English spelling. The LocalName was incorrectly "Labour," but it should have the local spelling of "Labor."

https://en.wikipedia.org/wiki/Public_holidays_in_the_United_States