### PR TITLE
Philippines - Fix Chinese New Year calculation

### DIFF
--- a/src/Nager.Date/HolidayProviders/PhilippinesHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/PhilippinesHolidayProvider.cs
@@ -234,6 +234,21 @@ namespace Nager.Date.HolidayProviders
             return null;
         }
 
+        private int MoveMonth(int month, int leapMonth)
+        {
+            if (leapMonth == 0)
+            {
+                return month;
+            }
+
+            if (leapMonth < month)
+            {
+                return ++month;
+            }
+
+            return month;
+        }
+
         /// <inheritdoc/>
         public override IEnumerable<string> GetSources()
         {


### PR DESCRIPTION
# Affected country
Philippines

# Affected public holiday
Chinese New Year

# Source of the information
https://www.officialgazette.gov.ph/nationwide-holidays/
