### PR TITLE
Latvia - Fix holiday names and add missing Vasarsvētki

### DIFF
--- a/src/Nager.Date/HolidayProviders/LatviaHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/LatviaHolidayProvider.cs
@@ -66,14 +66,6 @@ namespace Nager.Date.HolidayProviders
                     Date = new DateTime(year, 5, 4),
                     EnglishName = "Day of the Restoration of Independence of the Republic of Latvia",
                     LocalName = "Latvijas Republikas Neatkarības atjaunošanas diena",
-                    HolidayTypes = HolidayTypes.Public
-                },
-                new HolidaySpecification
-                {
-                    Id = "RESTORATIONOFINDEPENDENCE-02",
-                    Date = new DateTime(year, 5, 4),
-                    EnglishName = "Day of the Restoration of Independence of the Republic of Latvia",
-                    LocalName = "Latvijas Republikas Neatkarības atjaunošanas diena",
                     HolidayTypes = HolidayTypes.Public,
                     ObservedRuleSet = mondayObservedRuleSet
                 },
@@ -104,14 +96,6 @@ namespace Nager.Date.HolidayProviders
                 new HolidaySpecification
                 {
                     Id = "PROCLAMATIONDAY-01",
-                    Date = new DateTime(year, 11, 18),
-                    EnglishName = "Day of the Proclamation of the Republic of Latvia",
-                    LocalName = "Latvijas Republikas Proklamēšanas diena",
-                    HolidayTypes = HolidayTypes.Public
-                },
-                new HolidaySpecification
-                {
-                    Id = "PROCLAMATIONDAY-02",
                     Date = new DateTime(year, 11, 18),
                     EnglishName = "Day of the Proclamation of the Republic of Latvia",
                     LocalName = "Latvijas Republikas Proklamēšanas diena",


### PR DESCRIPTION
LocalName corrections (nominative case per Latvian grammar rules):
- "Jaunais Gads" → "Jaungada diena"
- "Lieldienas" → "Pirmās Lieldienas" (consistent with "Otrās Lieldienas")
- "Līgo Diena" → "Līgo diena" (lowercase 'd')
- "Jāņi" → "Jāņu diena"
- "proklamēšanas diena" → "Proklamēšanas diena" (uppercase 'P')
- "Ziemassvētki" → "Pirmie Ziemassvētki" (consistent with "Otrie Ziemassvētki")
- "Vecgada vakars" → "Vecgada diena"

EnglishName corrections (per official English translation of the law):
- "Restoration of Independence day" → "Day of the Restoration of Independence of the Republic of Latvia"
- "Midsummer Eve" → "Līgo Day"
- "Midsummer Day" → "Jāņi Day"
- "Proclamation Day of the Republic of Latvia" → "Day of the Proclamation of the Republic of Latvia"

Added missing public holiday:
- Vasarsvētki (Pentecost)

Updated source URL to the official law:
https://likumi.lv/doc.php?id=72608