### PR TITLE
Fix: Replace hardcoded date with dynamic Easter calculation for 'The day following Easter Monday' in Hong Kong. Fixes #960

### DIFF
--- a/src/Nager.Date.UnitTest/HongKongTest.cs
+++ b/src/Nager.Date.UnitTest/HongKongTest.cs
@@ -1,0 +1,28 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+
+namespace Nager.Date.UnitTest.Countries
+{
+    [TestClass]
+    public class HongKongTest
+    {
+        [TestMethod]
+        public void TestFollowingEasterMonday2025()
+        {
+            var holidays = HolidaySystem.GetHolidays(2025, CountryCode.HK);
+            var holiday = holidays.FirstOrDefault(h => h.EnglishName == "The day following Easter Monday");
+            Assert.IsNotNull(holiday);
+            Assert.AreEqual(new DateTime(2025, 4, 22), holiday.Date);
+        }
+
+        [TestMethod]
+        public void TestFollowingEasterMonday2026()
+        {
+            var holidays = HolidaySystem.GetHolidays(2026, CountryCode.HK);
+            var holiday = holidays.FirstOrDefault(h => h.EnglishName == "The day following Easter Monday");
+            Assert.IsNotNull(holiday);
+            Assert.AreEqual(new DateTime(2026, 4, 7), holiday.Date);
+        }
+    }
+}

--- a/src/Nager.Date/HolidayProviders/HongKongHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/HongKongHolidayProvider.cs
@@ -44,6 +44,15 @@ namespace Nager.Date.HolidayProviders
                     HolidayTypes = HolidayTypes.Public,
                     ObservedRuleSet = observedRuleSet
                 },
+                 new HolidaySpecification
+                {
+                    Id = "FOLLOWINGEASTERMONDAY-01",
+                    Date = easterSunday.AddDays(2),
+                    EnglishName = "The day following Easter Monday",
+                    LocalName = "復活節後第二日",
+                    HolidayTypes = HolidayTypes.Public,
+                    ObservedRuleSet = observedRuleSet
+                },
                 new HolidaySpecification
                 {
                     Id = "LABOURDAY-01",


### PR DESCRIPTION
The date for "The day following Easter Monday" was hardcoded to April 7, which is only correct for 2026. Replaced with a dynamic calculation based on EasterSunday + 2 days so it works correctly for all years. 