### PR TITLE
South Korea - Add local election day 2026

### DIFF
--- a/src/Nager.Date/HolidayProviders/SouthKoreaHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/SouthKoreaHolidayProvider.cs
@@ -67,7 +67,7 @@ namespace Nager.Date.HolidayProviders
             holidaySpecifications.AddIfNotNull(this.LiberationDay(year, weekendObservedRuleSet));
             holidaySpecifications.AddIfNotNull(this.NationalFoundationDay(year, weekendObservedRuleSet));
             holidaySpecifications.AddIfNotNull(this.HangulDay(year, weekendObservedRuleSet));
-            holidaySpecifications.AddRangeIfNotNull(this.GetKoreanLunisolarHolidays(year));
+            holidaySpecifications.AddRangeIfNotNull(this.GetKoreanLunisolarHolidays(year, weekendObservedRuleSet));
 
             return holidaySpecifications;
         }
@@ -202,7 +202,7 @@ namespace Nager.Date.HolidayProviders
             };
         }
 
-        private HolidaySpecification[] GetKoreanLunisolarHolidays(int year)
+        private HolidaySpecification[] GetKoreanLunisolarHolidays(int year, ObservedRuleSet observedRuleSet)
         {
             var holidaySpecifications = new List<HolidaySpecification>();
 
@@ -254,7 +254,8 @@ namespace Nager.Date.HolidayProviders
                     Date = buddhaBday,
                     EnglishName = "Buddha's Birthday",
                     LocalName = "부처님 오신 날",
-                    HolidayTypes = HolidayTypes.Public
+                    HolidayTypes = HolidayTypes.Public,
+                    ObservedRuleSet = year >= 2023 ? observedRuleSet : null
                 });
                 holidaySpecifications.Add(new HolidaySpecification
                 {

--- a/src/Nager.Date/HolidayProviders/SouthKoreaHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/SouthKoreaHolidayProvider.cs
@@ -69,6 +69,18 @@ namespace Nager.Date.HolidayProviders
             holidaySpecifications.AddIfNotNull(this.HangulDay(year, weekendObservedRuleSet));
             holidaySpecifications.AddRangeIfNotNull(this.GetKoreanLunisolarHolidays(year, weekendObservedRuleSet));
 
+            if (year == 2026)
+            {
+                holidaySpecifications.Add(new HolidaySpecification
+                {
+                    Id = "LOCALELECTIONDAY2026-01",
+                    Date = new DateTime(year, 6, 3),
+                    EnglishName = "Local Election Day",
+                    LocalName = "지방 선거일",
+                    HolidayTypes = HolidayTypes.Public
+                });
+            }
+
             return holidaySpecifications;
         }
 


### PR DESCRIPTION
Add korea local election day 2026.

- Build and tests are passing