### PR TITLE
fix #989: fix Christmas day zero-width spaces (Malta, Monaco)

### DIFF
--- a/src/Nager.Date/HolidayProviders/MaltaHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/MaltaHolidayProvider.cs
@@ -125,10 +125,10 @@ namespace Nager.Date.HolidayProviders
                 },
                 new HolidaySpecification
                 {
-                    Id = "​CHRISTMASDAY-01",
+                    Id = "CHRISTMASDAY-01",
                     Date = new DateTime(year, 12, 25),
-                    EnglishName = "​Christmas Day",
-                    LocalName = "Il-Milied​",
+                    EnglishName = "Christmas Day",
+                    LocalName = "Il-Milied",
                     HolidayTypes = HolidayTypes.Public
                 },
                 this._catholicProvider.GoodFriday("Il-Ġimgħa l-Kbira", year)

--- a/src/Nager.Date/HolidayProviders/MonacoHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/MonacoHolidayProvider.cs
@@ -95,10 +95,10 @@ namespace Nager.Date.HolidayProviders
                 },
                 new HolidaySpecification
                 {
-                    Id = "​CHRISTMASDAY-01",
+                    Id = "CHRISTMASDAY-01",
                     Date = new DateTime(year, 12, 25),
-                    EnglishName = "​Christmas Day",
-                    LocalName = "Noël​",
+                    EnglishName = "Christmas Day",
+                    LocalName = "Noël",
                     HolidayTypes = HolidayTypes.Public,
                     ObservedRuleSet = observedRuleSet
                 },


### PR DESCRIPTION
remove Zero-Width Space (ZWSP, \x{200B}) in Christmas Id, EnglishName, LocalName for Malta, Monaco