### PR TITLE
Germany - Fix Berlin Uprising of June 17 1953

### DIFF
--- a/src/Nager.Date/HolidayProviders/GermanyHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/GermanyHolidayProvider.cs
@@ -133,6 +133,7 @@ namespace Nager.Date.HolidayProviders
             holidaySpecifications.AddIfNotNull(this.LiberationDay(year));
             holidaySpecifications.AddIfNotNull(this.ReformationDay(year));
             holidaySpecifications.AddIfNotNull(this.WorldChildrensDay(year));
+            holidaySpecifications.AddIfNotNull(this.UprisingOfJune171953(year));
 
             return holidaySpecifications;
         }


### PR DESCRIPTION
This pull request adds a new holiday to the list of German holidays provided by the `GermanyHolidayProvider`. Specifically, it now includes the Uprising of June 17, 1953, in the holiday specifications.

Holiday specification update:

* Added the Uprising of June 17, 1953, as a recognized holiday in the `GetHolidaySpecifications` method of `GermanyHolidayProvider`.