### PR TITLE
Singapore - Fix public holidays for 2026 and 2027

### DIFF
--- a/src/Nager.Date/HolidayProviders/SingaporeHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/SingaporeHolidayProvider.cs
@@ -142,7 +142,7 @@ namespace Nager.Date.HolidayProviders
                     date = new DateTime(year, 3, 31);
                     break;
                 case 2026:
-                    date = new DateTime(year, 3, 20);
+                    date = new DateTime(year, 3, 21);
                     break;
                 case 2027:
                     date = new DateTime(year, 3, 10);
@@ -206,6 +206,12 @@ namespace Nager.Date.HolidayProviders
                 case 2025:
                     date = new DateTime(year, 5, 12);
                     break;
+                case 2026:
+                    date = new DateTime(year, 5, 31);
+                    break;
+                case 2027:
+                    date = new DateTime(year, 5, 20);
+                    break;
                 default:
                     break;
             }
@@ -268,11 +274,9 @@ namespace Nager.Date.HolidayProviders
                     break;
                 case 2026:
                     date = new DateTime(year, 5, 27);
-                    tentativeDate = true;
                     break;
                 case 2027:
                     date = new DateTime(year, 5, 17);
-                    tentativeDate = true;
                     break;
                 default:
                     break;
@@ -338,7 +342,7 @@ namespace Nager.Date.HolidayProviders
                     date = new DateTime(year, 11, 8);
                     break;
                 case 2027:
-                    date = new DateTime(year, 10, 29);
+                    date = new DateTime(year, 10, 28);
                     break;
                 default:
                     break;


### PR DESCRIPTION
## Summary

Corrects Singapore public holiday dates for 2026 and 2027, sourced from the official Ministry of Manpower calendar at https://www.mom.gov.sg/employment-practices/public-holidays.

- Hari Raya Puasa 2026: 20 Mar -> 21 Mar (off by one day)
- Vesak Day 2026: add 31 May (entry was missing entirely)
- Vesak Day 2027: add 20 May (entry was missing entirely)
- Hari Raya Haji 2026 and 2027: remove "(Tentative Date)" suffix, MOM has published confirmed dates
- Deepavali 2027: 29 Oct -> 28 Oct (off by one day)

## Source

ICS calendars downloaded directly from https://www.mom.gov.sg/employment-practices/public-holidays (Singapore Ministry of Manpower).
