### PR TITLE
Latvia - Add missing public holidays

### DIFF
--- a/src/Nager.Date.UnitTest/Countries/LatviaTest.cs
+++ b/src/Nager.Date.UnitTest/Countries/LatviaTest.cs
@@ -1,0 +1,70 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Nager.Date.Models;
+using System;
+using System.Linq;
+
+namespace Nager.Date.UnitTest.Countries
+{
+    [TestClass]
+    public class LatviaTest
+    {
+        [TestMethod]
+        public void TestLatviaPublicHolidays2024()
+        {
+            var publicHolidays = HolidaySystem.GetHolidays(2024, CountryCode.LV)
+                .Where(holiday => holiday.HolidayTypes.HasFlag(HolidayTypes.Public))
+                .ToArray();
+
+            Assert.AreEqual(16, publicHolidays.Length);
+
+            //4 May 2024 falls on a Saturday, the next working day is a holiday
+            var restorationDay = publicHolidays.Single(holiday => holiday.Id == "LV-RESTORATIONOFINDEPENDENCE-01");
+            Assert.AreEqual(new DateTime(2024, 5, 4), restorationDay.Date);
+            Assert.AreEqual(new DateTime(2024, 5, 6), restorationDay.ObservedDate);
+        }
+
+        [TestMethod]
+        [DataRow(2018, 7, 8, 9)]
+        [DataRow(2023, 7, 9, 10)]
+        [DataRow(2028, 7, 9, 10)]
+        public void TestSongAndDanceCelebrationFinalDay(int year, int month, int day, int observedDay)
+        {
+            var holiday = HolidaySystem.GetHolidays(year, CountryCode.LV)
+                .Single(h => h.Id == "LV-SONGANDDANCECELEBRATION-01");
+
+            Assert.AreEqual(new DateTime(year, month, day), holiday.Date);
+            Assert.AreEqual(new DateTime(year, month, observedDay), holiday.ObservedDate);
+            Assert.IsTrue(holiday.HolidayTypes.HasFlag(HolidayTypes.Public));
+        }
+
+        [TestMethod]
+        [DataRow(2017)]
+        [DataRow(2019)]
+        [DataRow(2024)]
+        public void TestNoSongAndDanceCelebrationDayInOtherYears(int year)
+        {
+            var holidayExists = HolidaySystem.GetHolidays(year, CountryCode.LV)
+                .Any(h => h.Id == "LV-SONGANDDANCECELEBRATION-01");
+
+            Assert.IsFalse(holidayExists);
+        }
+
+        [TestMethod]
+        public void TestOneOffPublicHolidays()
+        {
+            var holidays2018 = HolidaySystem.GetHolidays(2018, CountryCode.LV).ToArray();
+            var popeVisitDay = holidays2018.Single(h => h.Id == "LV-POPEFRANCISVISIT-01");
+            Assert.AreEqual(new DateTime(2018, 9, 24), popeVisitDay.Date);
+            Assert.IsTrue(popeVisitDay.HolidayTypes.HasFlag(HolidayTypes.Public));
+
+            var holidays2023 = HolidaySystem.GetHolidays(2023, CountryCode.LV).ToArray();
+            var iceHockeyDay = holidays2023.Single(h => h.Id == "LV-ICEHOCKEYBRONZEMEDAL-01");
+            Assert.AreEqual(new DateTime(2023, 5, 29), iceHockeyDay.Date);
+            Assert.IsTrue(iceHockeyDay.HolidayTypes.HasFlag(HolidayTypes.Public));
+
+            var holidays2019 = HolidaySystem.GetHolidays(2019, CountryCode.LV).ToArray();
+            Assert.IsFalse(holidays2019.Any(h => h.Id == "LV-POPEFRANCISVISIT-01"));
+            Assert.IsFalse(holidays2019.Any(h => h.Id == "LV-ICEHOCKEYBRONZEMEDAL-01"));
+        }
+    }
+}

--- a/src/Nager.Date/HolidayProviders/LatviaHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/LatviaHolidayProvider.cs
@@ -68,7 +68,7 @@ namespace Nager.Date.HolidayProviders
                     EnglishName = "Day of the Restoration of Independence of the Republic of Latvia",
                     LocalName = "Latvijas Republikas Neatkarības atjaunošanas diena",
                     HolidayTypes = HolidayTypes.Public,
-                    ObservedRuleSet = mondayObservedRuleSet
+                    ObservedRuleSet = mondayObservedRuleSet,
                 },
                 new HolidaySpecification
                 {
@@ -90,7 +90,7 @@ namespace Nager.Date.HolidayProviders
                 {
                     Id = "MIDSUMMERDAY-01",
                     Date = new DateTime(year, 6, 24),
-                    EnglishName = "Jāņi Day",
+                    EnglishName = "Jāņi Day", //St. John's Day
                     LocalName = "Jāņu diena",
                     HolidayTypes = HolidayTypes.Public,
                 },
@@ -101,7 +101,7 @@ namespace Nager.Date.HolidayProviders
                     EnglishName = "Day of the Proclamation of the Republic of Latvia",
                     LocalName = "Latvijas Republikas Proklamēšanas diena",
                     HolidayTypes = HolidayTypes.Public,
-                    ObservedRuleSet = mondayObservedRuleSet
+                    ObservedRuleSet = mondayObservedRuleSet,
                 },
                 new HolidaySpecification
                 {
@@ -138,7 +138,7 @@ namespace Nager.Date.HolidayProviders
                 this._catholicProvider.GoodFriday("Lielā Piektdiena", year),
                 this._catholicProvider.EasterSunday("Pirmās Lieldienas", year),
                 this._catholicProvider.EasterMonday("Otrās Lieldienas", year),
-                this._catholicProvider.Pentecost("Vasarsvētki", year)
+                this._catholicProvider.Pentecost("Vasarsvētki", year),
             };
 
             holidaySpecifications.AddIfNotNull(this.SongAndDanceCelebrationFinalDay(year, mondayObservedRuleSet));
@@ -172,13 +172,13 @@ namespace Nager.Date.HolidayProviders
                 EnglishName = "Final Day of the Nationwide Latvian Song and Dance Celebration",
                 LocalName = "Vispārējo latviešu Dziesmu un deju svētku noslēguma diena",
                 HolidayTypes = HolidayTypes.Public,
-                ObservedRuleSet = observedRuleSet
+                ObservedRuleSet = observedRuleSet,
             };
         }
 
         private HolidaySpecification? PopeFrancisPastoralVisitDay(int year)
         {
-            if (year != 2018)
+            if (year is not 2018)
             {
                 return null;
             }
@@ -195,7 +195,7 @@ namespace Nager.Date.HolidayProviders
 
         private HolidaySpecification? IceHockeyBronzeMedalDay(int year)
         {
-            if (year != 2023)
+            if (year is not 2023)
             {
                 return null;
             }

--- a/src/Nager.Date/HolidayProviders/LatviaHolidayProvider.cs
+++ b/src/Nager.Date/HolidayProviders/LatviaHolidayProvider.cs
@@ -1,3 +1,4 @@
+using Nager.Date.Extensions;
 using Nager.Date.Helpers;
 using Nager.Date.Models;
 using Nager.Date.ReligiousProviders;
@@ -120,9 +121,9 @@ namespace Nager.Date.HolidayProviders
                 },
                 new HolidaySpecification
                 {
-                    Id = "STSTEPHENSDAY-01",
+                    Id = "CHRISTMASDAY-02",
                     Date = new DateTime(year, 12, 26),
-                    EnglishName = "St. Stephen's Day",
+                    EnglishName = "Second day of Christmas",
                     LocalName = "Otrie Ziemassvētki",
                     HolidayTypes = HolidayTypes.Public,
                 },
@@ -140,7 +141,73 @@ namespace Nager.Date.HolidayProviders
                 this._catholicProvider.Pentecost("Vasarsvētki", year)
             };
 
+            holidaySpecifications.AddIfNotNull(this.SongAndDanceCelebrationFinalDay(year, mondayObservedRuleSet));
+            holidaySpecifications.AddIfNotNull(this.PopeFrancisPastoralVisitDay(year));
+            holidaySpecifications.AddIfNotNull(this.IceHockeyBronzeMedalDay(year));
+
             return holidaySpecifications;
+        }
+
+        private HolidaySpecification? SongAndDanceCelebrationFinalDay(int year, ObservedRuleSet observedRuleSet)
+        {
+            //The final day of the Nationwide Latvian Song and Dance Celebration, held every five years,
+            //is a public holiday (in the law since 22.10.2014), the date is fixed per event by a Cabinet order
+            DateTime? finalDay = year switch
+            {
+                2018 => new DateTime(2018, 7, 8),
+                2023 => new DateTime(2023, 7, 9),
+                2028 => new DateTime(2028, 7, 9),
+                _ => null
+            };
+
+            if (finalDay is null)
+            {
+                return null;
+            }
+
+            return new HolidaySpecification
+            {
+                Id = "SONGANDDANCECELEBRATION-01",
+                Date = finalDay.Value,
+                EnglishName = "Final Day of the Nationwide Latvian Song and Dance Celebration",
+                LocalName = "Vispārējo latviešu Dziesmu un deju svētku noslēguma diena",
+                HolidayTypes = HolidayTypes.Public,
+                ObservedRuleSet = observedRuleSet
+            };
+        }
+
+        private HolidaySpecification? PopeFrancisPastoralVisitDay(int year)
+        {
+            if (year != 2018)
+            {
+                return null;
+            }
+
+            return new HolidaySpecification
+            {
+                Id = "POPEFRANCISVISIT-01",
+                Date = new DateTime(2018, 9, 24),
+                EnglishName = "Day of the Pastoral Visit of His Holiness Pope Francis to Latvia",
+                LocalName = "Viņa Svētības pāvesta Franciska pastorālās vizītes Latvijā diena",
+                HolidayTypes = HolidayTypes.Public,
+            };
+        }
+
+        private HolidaySpecification? IceHockeyBronzeMedalDay(int year)
+        {
+            if (year != 2023)
+            {
+                return null;
+            }
+
+            return new HolidaySpecification
+            {
+                Id = "ICEHOCKEYBRONZEMEDAL-01",
+                Date = new DateTime(2023, 5, 29),
+                EnglishName = "Day of the Latvian Ice Hockey Team's Bronze Medal Win at the 2023 IIHF World Championship",
+                LocalName = "Diena, kad Latvijas hokeja komanda ieguva bronzas medaļu 2023. gada Pasaules hokeja čempionātā",
+                HolidayTypes = HolidayTypes.Public,
+            };
         }
 
         /// <inheritdoc/>
@@ -149,7 +216,8 @@ namespace Nager.Date.HolidayProviders
             return
             [
                 "https://en.wikipedia.org/wiki/Public_holidays_in_Latvia",
-                "https://likumi.lv/doc.php?id=72608"
+                "https://likumi.lv/doc.php?id=72608",
+                "https://likumi.lv/ta/en/en/id/72608-on-public-holidays-commemoration-days-and-celebration-days"
             ];
         }
     }


### PR DESCRIPTION
The law "Par svētku, atceres un atzīmējamām dienām" defines three public holidays that were missing from the provider:

- Final Day of the Nationwide Latvian Song and Dance Celebration - held every five years, date fixed per event by Cabinet order (2018-07-08, 2023-07-09, 2028-07-09). The same Saturday/Sunday observed rule as for 4 May and 18 November applies.
- 2018-09-24 - pastoral visit of Pope Francis (one-off)
- 2023-05-29 - Latvian ice hockey team bronze medal win (one-off)

Also renames 26 December from "St. Stephen's Day" to "Second day of Christmas" (Otrie Ziemassvētki), matching the law and the naming used by the Bulgaria and Svalbard providers; the Id changes from `LV-STSTEPHENSDAY-01` to `LV-CHRISTMASDAY-02`. Adds the official English translation of the law to the sources.

Sources:
- https://likumi.lv/ta/en/en/id/72608-on-public-holidays-commemoration-days-and-celebration-days
- https://likumi.lv/ta/id/367734-par-xxviii-visparejo-latviesu-dziesmu-un-xviii-deju-svetku-norises-laiku (2028 dates)
